### PR TITLE
Rename send to handle

### DIFF
--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -19,7 +19,7 @@ pub struct RegenState {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct RegenSendMsg {}
+pub struct RegenHandleMsg {}
 
 pub static CONFIG_KEY: &[u8] = b"config";
 
@@ -40,7 +40,7 @@ pub fn init<T: Storage>(
     Ok(Vec::new())
 }
 
-pub fn send<T: Storage>(
+pub fn handle<T: Storage>(
     store: &mut T,
     params: Params,
     _: Vec<u8>,
@@ -97,7 +97,7 @@ mod tests {
     }
 
     #[test]
-    fn proper_send() {
+    fn proper_handle() {
         let mut store = MockStorage::new();
 
         // initialize the store
@@ -111,10 +111,10 @@ mod tests {
         assert_eq!(0, init_res.len());
 
         // beneficiary can release it
-        let send_params = mock_params("verifies", &coin("15", "earth"), &coin("1015", "earth"));
-        let send_res = send(&mut store, send_params, Vec::new()).unwrap();
-        assert_eq!(1, send_res.len());
-        let msg = send_res.get(0).expect("no message");
+        let handle_params = mock_params("verifies", &coin("15", "earth"), &coin("1015", "earth"));
+        let handle_res = handle(&mut store, handle_params, Vec::new()).unwrap();
+        assert_eq!(1, handle_res.len());
+        let msg = handle_res.get(0).expect("no message");
         match &msg {
             CosmosMsg::SendTx {
                 from_address,
@@ -139,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_send() {
+    fn failed_handle() {
         let mut store = MockStorage::new();
 
         // initialize the store
@@ -153,9 +153,9 @@ mod tests {
         assert_eq!(0, init_res.len());
 
         // beneficiary can release it
-        let send_params = mock_params("benefits", &[], &coin("1000", "earth"));
-        let send_res = send(&mut store, send_params, Vec::new());
-        assert!(send_res.is_err());
+        let handle_params = mock_params("benefits", &[], &coin("1000", "earth"));
+        let handle_res = handle(&mut store, handle_params, Vec::new());
+        assert!(handle_res.is_err());
 
         // state should not change
         let data = store.get(CONFIG_KEY).expect("no data stored");

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -5,7 +5,7 @@ pub mod contract;
 pub use cosmwasm::exports::{allocate, deallocate};
 
 #[cfg(target_arch = "wasm32")]
-pub use wasm::{init_wrapper, send_wrapper};
+pub use wasm::{init_wrapper, handle_wrapper};
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
@@ -23,9 +23,9 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub extern "C" fn send_wrapper(params_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
-        exports::send(
-            &contract::send::<imports::ExternalStorage>,
+    pub extern "C" fn handle_wrapper(params_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+        exports::handle(
+            &contract::handle::<imports::ExternalStorage>,
             params_ptr,
             msg_ptr,
         )

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -5,7 +5,7 @@ pub mod contract;
 pub use cosmwasm::exports::{allocate, deallocate};
 
 #[cfg(target_arch = "wasm32")]
-pub use wasm::{init_wrapper, handle_wrapper};
+pub use wasm::{init, handle};
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
@@ -14,8 +14,8 @@ mod wasm {
     use std::ffi::c_void;
 
     #[no_mangle]
-    pub extern "C" fn init_wrapper(params_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
-        exports::init(
+    pub extern "C" fn init(params_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+        exports::do_init(
             &contract::init::<imports::ExternalStorage>,
             params_ptr,
             msg_ptr,
@@ -23,8 +23,8 @@ mod wasm {
     }
 
     #[no_mangle]
-    pub extern "C" fn handle_wrapper(params_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
-        exports::handle(
+    pub extern "C" fn handle(params_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+        exports::do_handle(
             &contract::handle::<imports::ExternalStorage>,
             params_ptr,
             msg_ptr,

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -4,8 +4,8 @@ use serde_json::{from_slice, to_vec};
 
 use cosmwasm::imports::Storage;
 use cosmwasm::types::{coin, mock_params, CosmosMsg};
-use cosmwasm_vm::{call_init, call_send, instantiate, with_storage};
-use hackatom::contract::{CONFIG_KEY, RegenInitMsg, RegenSendMsg, RegenState};
+use cosmwasm_vm::{call_init, call_handle, instantiate, with_storage};
+use hackatom::contract::{CONFIG_KEY, RegenInitMsg, RegenHandleMsg, RegenState};
 
 /**
 This integration test tries to run and call the generated wasm.
@@ -16,10 +16,10 @@ cargo wasm && wasm-gc ./target/wasm32-unknown-unknown/release/hackatom.wasm
 Then running `cargo test` will validate we can properly call into that generated data.
 **/
 
-// Note this is very similar in scope and size to proper_send in contracts.rs tests
+// Note this is very similar in scope and size to proper_handle in contracts.rs tests
 // Making it as easy to write vm external integration tests as rust unit tests
 #[test]
-fn successful_init_and_send() {
+fn successful_init_and_handle() {
     let wasm_file = "./target/wasm32-unknown-unknown/release/hackatom.wasm";
     let wasm = fs::read(wasm_file).unwrap();
     assert!(wasm.len() > 100000);
@@ -38,10 +38,10 @@ fn successful_init_and_send() {
     let msgs = res.unwrap();
     assert_eq!(msgs.len(), 0);
 
-    // now try to send this one
+    // now try to handle this one
     let params = mock_params("verifies", &coin("15", "earth"), &coin("1015", "earth"));
-    let msg = to_vec(&RegenSendMsg {}).unwrap();
-    let res = call_send(&mut instance, &params, &msg).unwrap();
+    let msg = to_vec(&RegenHandleMsg {}).unwrap();
+    let res = call_handle(&mut instance, &params, &msg).unwrap();
     let msgs = res.unwrap();
     assert_eq!(1, msgs.len());
     let msg = msgs.get(0).expect("no message");
@@ -71,7 +71,7 @@ fn successful_init_and_send() {
 }
 
 #[test]
-fn failed_send() {
+fn failed_handle() {
     let wasm_file = "./target/wasm32-unknown-unknown/release/hackatom.wasm";
     let wasm = fs::read(wasm_file).unwrap();
     assert!(wasm.len() > 100000);
@@ -87,9 +87,9 @@ fn failed_send() {
     assert_eq!(0, init_res.len());
 
     // beneficiary can release it
-    let send_params = mock_params("benefits", &[], &coin("1000", "earth"));
-    let send_res = call_send(&mut instance, &send_params, b"").unwrap();
-    assert!(send_res.is_err());
+    let handle_params = mock_params("benefits", &[], &coin("1000", "earth"));
+    let handle_res = call_handle(&mut instance, &handle_params, b"").unwrap();
+    assert!(handle_res.is_err());
 
     // state should be saved
     with_storage(&instance, |store| {

--- a/lib/vm/src/calls.rs
+++ b/lib/vm/src/calls.rs
@@ -26,7 +26,7 @@ pub fn call_init(
     Ok(res)
 }
 
-pub fn call_send(
+pub fn call_handle(
     instance: &mut Instance,
     params: &Params,
     msg: &[u8],
@@ -35,10 +35,10 @@ pub fn call_send(
     let params = to_vec(params)?;
     let param_offset = allocate(instance, &params);
     let msg_offset = allocate(instance, msg);
-    let send: Func<(i32, i32), (i32)> = instance.func("send_wrapper")?;
+    let handle: Func<(i32, i32), (i32)> = instance.func("handle_wrapper")?;
 
     // call function (failure cannot handle unwrap this error)
-    let res_offset = send.call(param_offset, msg_offset).unwrap();
+    let res_offset = handle.call(param_offset, msg_offset).unwrap();
 
     // read return value
     let data = read_memory(instance.context(), res_offset);

--- a/lib/vm/src/calls.rs
+++ b/lib/vm/src/calls.rs
@@ -15,7 +15,7 @@ pub fn call_init(
     let params = to_vec(params)?;
     let param_offset = allocate(instance, &params);
     let msg_offset = allocate(instance, msg);
-    let init: Func<(i32, i32), (i32)> = instance.func("init_wrapper")?;
+    let init: Func<(i32, i32), (i32)> = instance.func("init")?;
 
     // call function (failure cannot handle unwrap this error)
     let res_offset = init.call(param_offset, msg_offset).unwrap();
@@ -35,7 +35,7 @@ pub fn call_handle(
     let params = to_vec(params)?;
     let param_offset = allocate(instance, &params);
     let msg_offset = allocate(instance, msg);
-    let handle: Func<(i32, i32), (i32)> = instance.func("handle_wrapper")?;
+    let handle: Func<(i32, i32), (i32)> = instance.func("handle")?;
 
     // call function (failure cannot handle unwrap this error)
     let res_offset = handle.call(param_offset, msg_offset).unwrap();

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -3,6 +3,6 @@ mod exports;
 mod memory;
 mod wasmer;
 
-pub use crate::calls::{call_init, call_send};
+pub use crate::calls::{call_init, call_handle};
 pub use crate::memory::{allocate, read_memory};
 pub use crate::wasmer::{instantiate, with_storage};

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -26,8 +26,8 @@ pub extern "C" fn deallocate(pointer: *mut c_void) {
     mem::drop(consume_slice(pointer));
 }
 
-// init should be wrapped in an external "C" export, containing a contract-specific function as arg
-pub fn init(
+// do_init should be wrapped in an external "C" export, containing a contract-specific function as arg
+pub fn do_init(
     init_fn: &dyn Fn(&mut ExternalStorage, Params, Vec<u8>) -> Result<Vec<CosmosMsg>, Error>,
     params_ptr: *mut c_void,
     msg_ptr: *mut c_void,
@@ -58,8 +58,8 @@ pub fn init(
     release_buffer(res)
 }
 
-// handle should be wrapped in an external "C" export, containing a contract-specific function as arg
-pub fn handle(
+// do_handle should be wrapped in an external "C" export, containing a contract-specific function as arg
+pub fn do_handle(
     handle_fn: &dyn Fn(&mut ExternalStorage, Params, Vec<u8>) -> Result<Vec<CosmosMsg>, Error>,
     params_ptr: *mut c_void,
     msg_ptr: *mut c_void,

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -58,9 +58,9 @@ pub fn init(
     release_buffer(res)
 }
 
-// send should be wrapped in an external "C" export, containing a contract-specific function as arg
-pub fn send(
-    send_fn: &dyn Fn(&mut ExternalStorage, Params, Vec<u8>) -> Result<Vec<CosmosMsg>, Error>,
+// handle should be wrapped in an external "C" export, containing a contract-specific function as arg
+pub fn handle(
+    handle_fn: &dyn Fn(&mut ExternalStorage, Params, Vec<u8>) -> Result<Vec<CosmosMsg>, Error>,
     params_ptr: *mut c_void,
     msg_ptr: *mut c_void,
 ) -> *mut c_void {
@@ -75,7 +75,7 @@ pub fn send(
 
     // Catches and formats errors from the logic
     let mut store = ExternalStorage::new();
-    let res = match send_fn(&mut store, params, msg) {
+    let res = match handle_fn(&mut store, params, msg) {
         Ok(msgs) => ContractResult::Msgs(msgs),
         Err(e) => return make_error_c_string(e),
     };


### PR DESCRIPTION
Leave the two exported functions to be `init` and `handle`, rather than `init_wrapper` and `send_wrapper`. Clean up a bit of internal logic, but otherwise same interface