### PR TITLE
Wasm pack optimize (with Dockerfile)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 **/*.rs.bk
 *.iml
 contract.wasm
+/contracts/*/pkg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ maintenance = { status = "actively-developed" }
 
 [workspace]
 members = [ "lib/vm" ]
+exclude = [ "contracts/hackatom" ]
 
 [dependencies]
 serde_json = { version = "1.0.41" }

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,18 +1,18 @@
+# Usage
+# docker build . -t confio/cosmwasm-opt:latest
+# docker run --rm -v PATH/TO/CONTRACT/Cargo.toml:/code confio/cosmwasm-opt:latest
+# docker run --rm -v "$(pwd)":/code confio/cosmwasm-opt:latest
+# docker run --rm -it -v "$(pwd)":/code confio/cosmwasm-opt:latest /bin/bash
 FROM trzeci/emscripten:1.38.47
 
 # setup rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+ENV PATH /root/.cargo/bin:$PATH
 RUN rustup target add wasm32-unknown-unknown
 RUN mkdir -p /root/.cargo/bin
-ENV PATH /root/.cargo/bin:$PATH
 
 # setup wasm-pack
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-# install wasm-opt
-RUN git clone https://github.com/webassembly/binaryen
-RUN cd binaryen && cmake . && make
-RUN cp binaryen/bin/wasm-opt /root/.cargo/bin/wasm-opt
 
 # Assumes we mount the source code in /code
 WORKDIR /code

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,0 +1,22 @@
+FROM trzeci/emscripten:1.38.47
+
+# setup rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+RUN rustup target add wasm32-unknown-unknown
+RUN mkdir -p /root/.cargo/bin
+ENV PATH /root/.cargo/bin:$PATH
+
+# setup wasm-pack
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# install wasm-opt
+RUN git clone https://github.com/webassembly/binaryen
+RUN cd binaryen && cmake . && make
+RUN cp binaryen/bin/wasm-opt /root/.cargo/bin/wasm-opt
+
+# Assumes we mount the source code in /code
+WORKDIR /code
+ADD optimize.sh /root/optimize.sh
+RUN chmod +x /root/optimize.sh
+
+CMD ["/root/optimize.sh"]

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -186,6 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cosmwasm"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -195,8 +196,9 @@ dependencies = [
 [[package]]
 name = "cosmwasm-vm"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cosmwasm 0.1.0",
+ "cosmwasm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -382,8 +384,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "hackatom"
 version = "0.1.0"
 dependencies = [
- "cosmwasm 0.1.0",
- "cosmwasm-vm 0.1.0",
+ "cosmwasm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-vm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1081,6 +1083,8 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+"checksum cosmwasm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ed2d07f76a20f189cf525cf1c48fac79a0386bffa71395c8c88acde6f74590e"
+"checksum cosmwasm-vm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91302734e4d9ec8b868e5d3e64c42a0be560602f84f79c607cbce610d4da59b2"
 "checksum cranelift-bforest 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fff04f4ad82c9704a22e753c6268cc6a89add76f094b837cefbba1c665411451"
 "checksum cranelift-codegen 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ff4a221ec1b95df4b1d20a99fec4fe92a28bebf3a815f2eca72b26f9a627485"
 "checksum cranelift-codegen-meta 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd47f665e2ee8f177b97d1f5ce2bd70f54d3b793abb26d92942bfaa4a381fe9f"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -111,6 +111,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +190,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -844,6 +850,55 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "wasmer-clif-backend"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1071,7 @@ dependencies = [
 "checksum bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 "checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 "checksum blake2b_simd 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5850aeee1552f495dd0250014cf64b82b7c8879a89d83b33bbdace2cc4f63182"
+"checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
@@ -1106,6 +1162,11 @@ dependencies = [
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "cd34c5ba0d228317ce388e87724633c57edca3e7531feb4e25e35aaa07a656af"
+"checksum wasm-bindgen-backend 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "927196b315c23eed2748442ba675a4c54a1a079d90d9bdc5ad16ce31cf90b15b"
+"checksum wasm-bindgen-macro 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "92c2442bf04d89792816650820c3fb407af8da987a9f10028d5317f5b04c2b4a"
+"checksum wasm-bindgen-macro-support 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "9c075d27b7991c68ca0f77fe628c3513e64f8c477d422b859e03f28751b46fc5"
+"checksum wasm-bindgen-shared 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "83d61fe986a7af038dd8b5ec660e5849cbd9f38e7492b9404cc48b2b4df731d1"
 "checksum wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67e7a747aff0449ab4639e6f1f3c5ec5a3a1099685d34fcabf4628b5b031944c"
 "checksum wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf2f552a9c1fda0555087170424bd8fedc63a079a97bb5638a4ef9b0d9656aa"
 "checksum wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0073b512e1af5948d34be7944b74c747bbe735ccff2e2f28c26ed4c90725de8e"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -190,7 +190,6 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -388,6 +387,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -21,11 +21,14 @@ incremental = false
 overflow-checks = true
 
 [dependencies]
-cosmwasm = { version = "0.1.0", path = "../.." }
+# TODO: it seems the docker image only works when we have absolute references...
+#cosmwasm = { version = "0.1.0", path = "../.." }
+cosmwasm = { version = "0.1.0" }
 wasm-bindgen = "0.2"
 serde_json = { version = "1.0.41" }
 serde = { version = "1.0.60", default-features = false, features = ["derive"] }
 failure = "0.1.5"
 
 [dev-dependencies]
-cosmwasm-vm = { version = "0.1.0", path = "../../lib/vm" }
+#cosmwasm-vm = { version = "0.1.0", path = "../../lib/vm" }
+cosmwasm-vm = { version = "0.1.0" }

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -24,6 +24,7 @@ overflow-checks = true
 
 [dependencies]
 cosmwasm = { path = "../.." }
+wasm-bindgen = "0.2"
 serde_json = { version = "1.0.41" }
 serde = { version = "1.0.60", default-features = false, features = ["derive"] }
 failure = "0.1.5"

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -20,14 +20,12 @@ panic = 'unwind'
 incremental = false
 overflow-checks = true
 
-[workspace]
-
 [dependencies]
-cosmwasm = { path = "../.." }
+cosmwasm = { version = "0.1.0", path = "../.." }
 wasm-bindgen = "0.2"
 serde_json = { version = "1.0.41" }
 serde = { version = "1.0.60", default-features = false, features = ["derive"] }
 failure = "0.1.5"
 
 [dev-dependencies]
-cosmwasm-vm = { path = "../../lib/vm" }
+cosmwasm-vm = { version = "0.1.0", path = "../../lib/vm" }

--- a/contracts/hackatom/README.md
+++ b/contracts/hackatom/README.md
@@ -3,3 +3,12 @@ Compiling
 `cargo wasm` does a basic compilation step, you need to run `wasm-gc <file>.wasm` to shrink it down afterwards.
 
 `wasm-pack build` does the wasm compilation and trimming in one step. See if it is worth it
+
+Deep optimization: use wasm-opt.
+Produces around additional 25% savings on top of wasm-pack.
+
+(Note `cargo wasm` fails if we use wasm_bindgen decorator... )
+
+**TODO**
+
+Prepare wasm-pack and wasm-opt pipeline for "productivication"

--- a/contracts/hackatom/README.md
+++ b/contracts/hackatom/README.md
@@ -1,0 +1,5 @@
+Compiling
+
+`cargo wasm` does a basic compilation step, you need to run `wasm-gc <file>.wasm` to shrink it down afterwards.
+
+`wasm-pack build` does the wasm compilation and trimming in one step. See if it is worth it

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -8,8 +8,11 @@ use cosmwasm_vm::{call_handle, call_init, instantiate, with_storage};
 use hackatom::contract::{RegenHandleMsg, RegenInitMsg, RegenState, CONFIG_KEY};
 
 
-//static WASM_FILE: &str = "./target/wasm32-unknown-unknown/release/hackatom.wasm";
-static WASM_FILE: &str = "./pkg/hackatom_opt2.wasm";
+// this is generated directly from `cargo wasm` - dev mode
+static WASM_FILE: &str = "./target/wasm32-unknown-unknown/release/hackatom.wasm";
+
+// this is generated from the optimize.sh script (or Dockerfile) and is minimized, production-ready
+//static WASM_FILE: &str = "./contract.wasm";
 
 /**
 This integration test tries to run and call the generated wasm.

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -7,6 +7,10 @@ use cosmwasm::types::{coin, mock_params, CosmosMsg};
 use cosmwasm_vm::{call_handle, call_init, instantiate, with_storage};
 use hackatom::contract::{RegenHandleMsg, RegenInitMsg, RegenState, CONFIG_KEY};
 
+
+//static WASM_FILE: &str = "./target/wasm32-unknown-unknown/release/hackatom.wasm";
+static WASM_FILE: &str = "./pkg/hackatom_bg.wasm";
+
 /**
 This integration test tries to run and call the generated wasm.
 It depends on a release build being available already. You can create that with:
@@ -20,8 +24,7 @@ Then running `cargo test` will validate we can properly call into that generated
 // Making it as easy to write vm external integration tests as rust unit tests
 #[test]
 fn successful_init_and_handle() {
-    let wasm_file = "./target/wasm32-unknown-unknown/release/hackatom.wasm";
-    let wasm = fs::read(wasm_file).unwrap();
+    let wasm = fs::read(WASM_FILE).unwrap();
     assert!(wasm.len() > 100000);
     let mut instance = instantiate(&wasm);
 
@@ -72,8 +75,7 @@ fn successful_init_and_handle() {
 
 #[test]
 fn failed_handle() {
-    let wasm_file = "./target/wasm32-unknown-unknown/release/hackatom.wasm";
-    let wasm = fs::read(wasm_file).unwrap();
+    let wasm = fs::read(WASM_FILE).unwrap();
     assert!(wasm.len() > 100000);
     let mut instance = instantiate(&wasm);
 

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -9,7 +9,7 @@ use hackatom::contract::{RegenHandleMsg, RegenInitMsg, RegenState, CONFIG_KEY};
 
 
 //static WASM_FILE: &str = "./target/wasm32-unknown-unknown/release/hackatom.wasm";
-static WASM_FILE: &str = "./pkg/hackatom_bg.wasm";
+static WASM_FILE: &str = "./pkg/hackatom_opt2.wasm";
 
 /**
 This integration test tries to run and call the generated wasm.

--- a/contracts/optimize.sh
+++ b/contracts/optimize.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+outdir=$(mktemp -d)
+wasm-pack build --out-dir "${outdir}"
+wasm-opt -Os "${outdir}"/*.wasm -o contract.wasm

--- a/contracts/optimize.sh
+++ b/contracts/optimize.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+export PATH=$PATH:/root/.cargo/bin
+echo $PATH
+which wasm-pack
+which wasm-opt
+
 outdir=$(mktemp -d)
-wasm-pack build --out-dir "${outdir}"
+echo
+pwd
+ls
+echo wasm-pack build --out-dir "${outdir}"
+
+wasm-pack build --out-dir "${outdir}" || true
+wasm-pack build --out-dir "${outdir}" || true
+echo wasm-opt -Os "${outdir}"/*.wasm -o contract.wasm
 wasm-opt -Os "${outdir}"/*.wasm -o contract.wasm
+echo "done"

--- a/contracts/optimize.sh
+++ b/contracts/optimize.sh
@@ -3,18 +3,12 @@
 set -e
 
 export PATH=$PATH:/root/.cargo/bin
-echo $PATH
-which wasm-pack
-which wasm-opt
-
 outdir=$(mktemp -d)
-echo
-pwd
-ls
-echo wasm-pack build --out-dir "${outdir}"
 
+echo wasm-pack build --out-dir "${outdir}"
 wasm-pack build --out-dir "${outdir}" || true
-wasm-pack build --out-dir "${outdir}" || true
+
 echo wasm-opt -Os "${outdir}"/*.wasm -o contract.wasm
 wasm-opt -Os "${outdir}"/*.wasm -o contract.wasm
+
 echo "done"


### PR DESCRIPTION
Closes #6 

This creates a script (and a dockerfile for those who don't want to download all dependencies) that does the optimization steps on the contract.wasm.

Demo on hackatom got from 1.5MB (unoptimized) to 174kB (wasm-gc) down to 128kB (wasm-pack + wasm-opt)