### PR TITLE
Change output format

### DIFF
--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -22,6 +22,12 @@ overflow-checks = true
 
 [workspace]
 
+[features]
+default = [ "integration" ]
+# this enables integration testing (takes longer)
+# for quicker tests, cargo test --no-default-features
+integration = [ ]
+
 [dependencies]
 cosmwasm = { path = "../.." }
 serde_json = { version = "1.0.41" }

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -1,25 +1,25 @@
 use cosmwasm::storage::Storage;
-use cosmwasm::types::{CosmosMsg, Params};
+use cosmwasm::types::{CosmosMsg, Params, Response};
 
 use failure::{bail, format_err, Error};
 use serde::{Deserialize, Serialize};
 use serde_json::{from_slice, to_vec};
 
 #[derive(Serialize, Deserialize)]
-pub struct RegenInitMsg {
+pub struct InitMsg {
     pub verifier: String,
     pub beneficiary: String,
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct RegenState {
+pub struct State {
     pub verifier: String,
     pub beneficiary: String,
     pub funder: String,
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct RegenHandleMsg {}
+pub struct HandleMsg {}
 
 pub static CONFIG_KEY: &[u8] = b"config";
 
@@ -27,35 +27,39 @@ pub fn init<T: Storage>(
     store: &mut T,
     params: Params,
     msg: Vec<u8>,
-) -> Result<Vec<CosmosMsg>, Error> {
-    let msg: RegenInitMsg = from_slice(&msg)?;
+) -> Result<Response, Error> {
+    let msg: InitMsg = from_slice(&msg)?;
     store.set(
         CONFIG_KEY,
-        &to_vec(&RegenState {
+        &to_vec(&State {
             verifier: msg.verifier,
             beneficiary: msg.beneficiary,
             funder: params.message.signer,
         })?,
     );
-    Ok(Vec::new())
+    Ok(Response::default())
 }
 
 pub fn handle<T: Storage>(
     store: &mut T,
     params: Params,
     _: Vec<u8>,
-) -> Result<Vec<CosmosMsg>, Error> {
+) -> Result<Response, Error> {
     let data = store
         .get(CONFIG_KEY)
         .ok_or(format_err!("not initialized"))?;
-    let state: RegenState = from_slice(&data)?;
+    let state: State = from_slice(&data)?;
 
     if params.message.signer == state.verifier {
-        Ok(vec![CosmosMsg::SendTx {
-            from_address: params.contract.address,
-            to_address: state.beneficiary,
-            amount: params.contract.balance,
-        }])
+        let res = Response{
+            messages: vec![CosmosMsg::SendTx {
+                from_address: params.contract.address,
+                to_address: state.beneficiary,
+                amount: params.contract.balance,
+            }],
+            log: Some("released funds!".to_string()),
+        };
+        Ok(res)
     } else {
         bail!("Unauthorized")
     }
@@ -70,18 +74,18 @@ mod tests {
     #[test]
     fn proper_initialization() {
         let mut store = MockStorage::new();
-        let msg = serde_json::to_vec(&RegenInitMsg {
+        let msg = serde_json::to_vec(&InitMsg {
             verifier: String::from("verifies"),
             beneficiary: String::from("benefits"),
         })
         .unwrap();
         let params = mock_params("creator", &coin("1000", "earth"), &[]);
         let res = init(&mut store, params, msg).unwrap();
-        assert_eq!(0, res.len());
+        assert_eq!(0, res.messages.len());
 
         // it worked, let's check the state
         let data = store.get(CONFIG_KEY).expect("no data stored");
-        let state: RegenState = from_slice(&data).unwrap();
+        let state: State = from_slice(&data).unwrap();
         assert_eq!(state.verifier, String::from("verifies"));
         assert_eq!(state.beneficiary, String::from("benefits"));
         assert_eq!(state.funder, String::from("creator"));
@@ -101,20 +105,20 @@ mod tests {
         let mut store = MockStorage::new();
 
         // initialize the store
-        let init_msg = serde_json::to_vec(&RegenInitMsg {
+        let init_msg = serde_json::to_vec(&InitMsg {
             verifier: String::from("verifies"),
             beneficiary: String::from("benefits"),
         })
         .unwrap();
         let init_params = mock_params("creator", &coin("1000", "earth"), &coin("1000", "earth"));
         let init_res = init(&mut store, init_params, init_msg).unwrap();
-        assert_eq!(0, init_res.len());
+        assert_eq!(0, init_res.messages.len());
 
         // beneficiary can release it
         let handle_params = mock_params("verifies", &coin("15", "earth"), &coin("1015", "earth"));
         let handle_res = handle(&mut store, handle_params, Vec::new()).unwrap();
-        assert_eq!(1, handle_res.len());
-        let msg = handle_res.get(0).expect("no message");
+        assert_eq!(1, handle_res.messages.len());
+        let msg = handle_res.messages.get(0).expect("no message");
         match &msg {
             CosmosMsg::SendTx {
                 from_address,
@@ -132,7 +136,7 @@ mod tests {
 
         // it worked, let's check the state
         let data = store.get(CONFIG_KEY).expect("no data stored");
-        let state: RegenState = from_slice(&data).unwrap();
+        let state: State = from_slice(&data).unwrap();
         assert_eq!(state.verifier, String::from("verifies"));
         assert_eq!(state.beneficiary, String::from("benefits"));
         assert_eq!(state.funder, String::from("creator"));
@@ -143,14 +147,14 @@ mod tests {
         let mut store = MockStorage::new();
 
         // initialize the store
-        let init_msg = serde_json::to_vec(&RegenInitMsg {
+        let init_msg = serde_json::to_vec(&InitMsg {
             verifier: String::from("verifies"),
             beneficiary: String::from("benefits"),
         })
         .unwrap();
         let init_params = mock_params("creator", &coin("1000", "earth"), &coin("1000", "earth"));
         let init_res = init(&mut store, init_params, init_msg).unwrap();
-        assert_eq!(0, init_res.len());
+        assert_eq!(0, init_res.messages.len());
 
         // beneficiary can release it
         let handle_params = mock_params("benefits", &[], &coin("1000", "earth"));
@@ -159,7 +163,7 @@ mod tests {
 
         // state should not change
         let data = store.get(CONFIG_KEY).expect("no data stored");
-        let state: RegenState = from_slice(&data).unwrap();
+        let state: State = from_slice(&data).unwrap();
         assert_eq!(state.verifier, String::from("verifies"));
         assert_eq!(state.beneficiary, String::from("benefits"));
         assert_eq!(state.funder, String::from("creator"));

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(1, handle_res.messages.len());
         let msg = handle_res.messages.get(0).expect("no message");
         match &msg {
-            CosmosMsg::SendTx {
+            CosmosMsg::Send {
                 from_address,
                 to_address,
                 amount,
@@ -132,7 +132,8 @@ mod tests {
                 let coin = amount.get(0).expect("No coin");
                 assert_eq!(coin.denom, "earth");
                 assert_eq!(coin.amount, "1015");
-            }
+            },
+            _ => panic!("Unexpected message type")
         }
 
         // it worked, let's check the state

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -52,12 +52,13 @@ pub fn handle<T: Storage>(
 
     if params.message.signer == state.verifier {
         let res = Response{
-            messages: vec![CosmosMsg::SendTx {
+            messages: vec![CosmosMsg::Send {
                 from_address: params.contract.address,
                 to_address: state.beneficiary,
                 amount: params.contract.balance,
             }],
             log: Some("released funds!".to_string()),
+            data: None,
         };
         Ok(res)
     } else {

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use std::fs;
 
 use serde_json::{from_slice, to_vec};
@@ -46,7 +48,7 @@ fn successful_init_and_handle() {
     assert_eq!(1, msgs.len());
     let msg = msgs.get(0).expect("no message");
     match &msg {
-        CosmosMsg::SendTx {
+        CosmosMsg::Send {
             from_address,
             to_address,
             amount,
@@ -57,7 +59,8 @@ fn successful_init_and_handle() {
             let coin = amount.get(0).expect("No coin");
             assert_eq!(coin.denom, "earth");
             assert_eq!(coin.amount, "1015");
-        }
+        },
+        _ => panic!("Unexpected message type")
     }
 
     // we can check the storage as well

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -5,7 +5,7 @@ use serde_json::{from_slice, to_vec};
 use cosmwasm::storage::Storage;
 use cosmwasm::types::{coin, mock_params, CosmosMsg};
 use cosmwasm_vm::{call_handle, call_init, instantiate, with_storage};
-use hackatom::contract::{RegenHandleMsg, RegenInitMsg, RegenState, CONFIG_KEY};
+use hackatom::contract::{HandleMsg, InitMsg, State, CONFIG_KEY};
 
 /**
 This integration test tries to run and call the generated wasm.
@@ -27,7 +27,7 @@ fn successful_init_and_handle() {
 
     // prepare arguments
     let params = mock_params("creator", &coin("1000", "earth"), &[]);
-    let msg = to_vec(&RegenInitMsg {
+    let msg = to_vec(&InitMsg {
         verifier: String::from("verifies"),
         beneficiary: String::from("benefits"),
     })
@@ -35,14 +35,14 @@ fn successful_init_and_handle() {
 
     // call and check
     let res = call_init(&mut instance, &params, &msg).unwrap();
-    let msgs = res.unwrap();
+    let msgs = res.unwrap().messages;
     assert_eq!(msgs.len(), 0);
 
     // now try to handle this one
     let params = mock_params("verifies", &coin("15", "earth"), &coin("1015", "earth"));
-    let msg = to_vec(&RegenHandleMsg {}).unwrap();
+    let msg = to_vec(&HandleMsg {}).unwrap();
     let res = call_handle(&mut instance, &params, &msg).unwrap();
-    let msgs = res.unwrap();
+    let msgs = res.unwrap().messages;
     assert_eq!(1, msgs.len());
     let msg = msgs.get(0).expect("no message");
     match &msg {
@@ -65,7 +65,7 @@ fn successful_init_and_handle() {
         let foo = store.get(b"foo");
         assert!(foo.is_none());
         let data = store.get(CONFIG_KEY).expect("no data stored");
-        let state: RegenState = from_slice(&data).unwrap();
+        let state: State = from_slice(&data).unwrap();
         assert_eq!(state.verifier, String::from("verifies"));
     });
 }
@@ -78,16 +78,15 @@ fn failed_handle() {
     let mut instance = instantiate(&wasm);
 
     // initialize the store
-    let init_msg = serde_json::to_vec(&RegenInitMsg {
+    let init_msg = serde_json::to_vec(&InitMsg {
         verifier: String::from("verifies"),
         beneficiary: String::from("benefits"),
     })
     .unwrap();
     let init_params = mock_params("creator", &coin("1000", "earth"), &coin("1000", "earth"));
-    let init_res = call_init(&mut instance, &init_params, &init_msg)
-        .unwrap()
-        .unwrap();
-    assert_eq!(0, init_res.len());
+    let init_res = call_init(&mut instance, &init_params, &init_msg).unwrap();
+    let init_msgs = init_res.unwrap().messages;
+    assert_eq!(0, init_msgs.len());
 
     // beneficiary can release it
     let handle_params = mock_params("benefits", &[], &coin("1000", "earth"));
@@ -97,7 +96,7 @@ fn failed_handle() {
     // state should be saved
     with_storage(&instance, |store| {
         let data = store.get(CONFIG_KEY).expect("no data stored");
-        let state: RegenState = from_slice(&data).unwrap();
+        let state: State = from_slice(&data).unwrap();
         assert_eq!(state.verifier, String::from("verifies"));
     });
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,17 +18,17 @@ pub struct BlockInfo {
 #[derive(Serialize, Deserialize)]
 pub struct MessageInfo {
     pub signer: String,
-    pub sent_funds: Vec<SendAmount>,
+    pub sent_funds: Vec<Coin>,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct ContractInfo {
     pub address: String,
-    pub balance: Vec<SendAmount>,
+    pub balance: Vec<Coin>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct SendAmount {
+pub struct Coin {
     pub denom: String,
     pub amount: String,
 }
@@ -39,7 +39,7 @@ pub enum CosmosMsg {
     SendTx {
         from_address: String,
         to_address: String,
-        amount: Vec<SendAmount>,
+        amount: Vec<Coin>,
     },
 }
 
@@ -78,7 +78,7 @@ pub struct Response {
 
 // just set signer, sent funds, and balance - rest given defaults
 // this is intended for use in testcode only
-pub fn mock_params(signer: &str, sent: &[SendAmount], balance: &[SendAmount]) -> Params {
+pub fn mock_params(signer: &str, sent: &[Coin], balance: &[Coin]) -> Params {
     Params {
         block: BlockInfo {
             height: 12345,
@@ -97,8 +97,8 @@ pub fn mock_params(signer: &str, sent: &[SendAmount], balance: &[SendAmount]) ->
 }
 
 // coin is a shortcut constructor for a set of one denomination of coins
-pub fn coin(amount: &str, denom: &str) -> Vec<SendAmount> {
-    vec![SendAmount {
+pub fn coin(amount: &str, denom: &str) -> Vec<Coin> {
+    vec![Coin {
         amount: amount.to_string(),
         denom: denom.to_string(),
     }]

--- a/src/types.rs
+++ b/src/types.rs
@@ -52,13 +52,6 @@ pub enum ContractResult {
     Err(String),
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct Response {
-    // let's make the positive case a struct, it contrains Msg: {...}, but also Data, Log, maybe later Events, etc.
-    pub messages: Vec<CosmosMsg>,
-    pub log: String,
-}
-
 impl ContractResult {
     // unwrap will panic on err, or give us the real data useful for tests
     pub fn unwrap(self) -> Response {
@@ -74,6 +67,13 @@ impl ContractResult {
             _ => false,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Response {
+    // let's make the positive case a struct, it contrains Msg: {...}, but also Data, Log, maybe later Events, etc.
+    pub messages: Vec<CosmosMsg>,
+    pub log: Option<String>,
 }
 
 // just set signer, sent funds, and balance - rest given defaults

--- a/src/types.rs
+++ b/src/types.rs
@@ -43,25 +43,34 @@ pub enum CosmosMsg {
     },
 }
 
+// TODO: clean this up - let's us a normal result type??? or at least normal terms
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ContractResult {
-    Msgs(Vec<CosmosMsg>),
-    Error(String),
+    Ok(Response),
+    Err(String),
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Response {
+    // let's make the positive case a struct, it contrains Msg: {...}, but also Data, Log, maybe later Events, etc.
+    pub messages: Vec<CosmosMsg>,
+    pub log: String,
 }
 
 impl ContractResult {
     // unwrap will panic on err, or give us the real data useful for tests
-    pub fn unwrap(self) -> Vec<CosmosMsg> {
+    pub fn unwrap(self) -> Response {
         match self {
-            ContractResult::Error(msg) => panic!("Unexpected error: {}", msg),
-            ContractResult::Msgs(msgs) => msgs,
+            ContractResult::Err(msg) => panic!("Unexpected error: {}", msg),
+            ContractResult::Ok(res) => res,
         }
     }
 
     pub fn is_err(&self) -> bool {
         match self {
-            ContractResult::Error(_) => true,
+            ContractResult::Err(_) => true,
             _ => false,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,12 +34,23 @@ pub struct Coin {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum CosmosMsg {
-    #[serde(rename = "send")]
-    SendTx {
+    // this moves tokens in the underlying sdk
+    Send {
         from_address: String,
         to_address: String,
         amount: Vec<Coin>,
+    },
+    // this dispatches a call to another contract at a known address (with known ABI)
+    // msg is the json-encoded HandleMsg struct
+    Contract {
+        contract_addr: String,
+        msg: String,
+    },
+    // this should never be created here, just passed in from the user and later dispatched
+    Opaque {
+        data: String,
     },
 }
 
@@ -74,6 +85,7 @@ pub struct Response {
     // let's make the positive case a struct, it contrains Msg: {...}, but also Data, Log, maybe later Events, etc.
     pub messages: Vec<CosmosMsg>,
     pub log: Option<String>,
+    pub data: Option<String>,
 }
 
 // just set signer, sent funds, and balance - rest given defaults


### PR DESCRIPTION
Clarify the output Result to contain more info than `Vec<CosmosMsg>` on success... allowing log, data, or later events and tags.

Note this is a breaking API change for 0.2

- [x] Ensure we syncronize the types in go-cosmwasm and cosmwasm (esp. CosmosMsg enum)