### PR TITLE
Cache and validate module on save 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install CMAKE
+          command: 'apt-get update && apt-get install -y cmake'
+      - run:
           name: Version information
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,15 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "c2-chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,7 +230,7 @@ dependencies = [
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -390,11 +399,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +409,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -588,6 +602,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,28 +645,40 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.3.1"
+name = "rand_chacha"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -679,14 +710,6 @@ dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -875,12 +898,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
+name = "tempfile"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -962,6 +989,11 @@ dependencies = [
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasmer-clif-backend"
@@ -1140,6 +1172,7 @@ dependencies = [
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -1166,9 +1199,9 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -1193,18 +1226,19 @@ dependencies = [
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+"checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afdc77cc74ec70ed262262942ebb7dac3d479e9e5cfa2da1841c0806f6cdabcc"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+"checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30a9d219c32c9132f7be513c18be77c9881c7107d2ab5569d205a6a0f0e6dc7d"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
@@ -1229,7 +1263,7 @@ dependencies = [
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7975cb2c6f37d77b190bc5004a2bb015971464756fde9514651a525ada2a741a"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -1242,6 +1276,7 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"
 "checksum wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af5d153dc96aad7dc13ab90835b892c69867948112d95299e522d370c4e13a08"
+"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67e7a747aff0449ab4639e6f1f3c5ec5a3a1099685d34fcabf4628b5b031944c"
 "checksum wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf2f552a9c1fda0555087170424bd8fedc63a079a97bb5638a4ef9b0d9656aa"
 "checksum wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0073b512e1af5948d34be7944b74c747bbe735ccff2e2f28c26ed4c90725de8e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,9 +218,11 @@ dependencies = [
  "cosmwasm 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -404,6 +406,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "glob"
@@ -936,6 +943,27 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wabt"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wabt-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasmer-clif-backend"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1169,7 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
@@ -1211,6 +1240,8 @@ dependencies = [
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"
+"checksum wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af5d153dc96aad7dc13ab90835b892c69867948112d95299e522d370c4e13a08"
 "checksum wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67e7a747aff0449ab4639e6f1f3c5ec5a3a1099685d34fcabf4628b5b031944c"
 "checksum wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf2f552a9c1fda0555087170424bd8fedc63a079a97bb5638a4ef9b0d9656aa"
 "checksum wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0073b512e1af5948d34be7944b74c747bbe735ccff2e2f28c26ed4c90725de8e"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "cosmwasm 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -20,6 +20,9 @@ failure = "0.1.5"
 serde_json = { version = "1.0.41" }
 sha2 = "0.8.0"
 hex = "0.3.1"
+memmap = "0.7"
 
 [dev-dependencies]
+# move to tempfile "3.1.0"
 tempdir = "0.3.7"
+wabt = "0.9.1"

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -23,6 +23,5 @@ hex = "0.3.1"
 memmap = "0.7"
 
 [dev-dependencies]
-# move to tempfile "3.1.0"
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 wabt = "0.9.1"

--- a/lib/vm/src/backends/cranelift.rs
+++ b/lib/vm/src/backends/cranelift.rs
@@ -1,5 +1,5 @@
 use wasmer_clif_backend::CraneliftCompiler;
-use wasmer_runtime::{Backend, compile_with, Module};
+use wasmer_runtime::{compile_with, Backend, Module};
 
 pub fn compile(code: &[u8]) -> Module {
     compile_with(code, &CraneliftCompiler::new()).unwrap()

--- a/lib/vm/src/backends/cranelift.rs
+++ b/lib/vm/src/backends/cranelift.rs
@@ -1,6 +1,10 @@
 use wasmer_clif_backend::CraneliftCompiler;
-use wasmer_runtime::{compile_with, Module};
+use wasmer_runtime::{Backend, compile_with, Module};
 
 pub fn compile(code: &[u8]) -> Module {
     compile_with(code, &CraneliftCompiler::new()).unwrap()
+}
+
+pub fn backend() -> Backend {
+    Backend::Cranelift
 }

--- a/lib/vm/src/backends/cranelift.rs
+++ b/lib/vm/src/backends/cranelift.rs
@@ -1,0 +1,6 @@
+use wasmer_clif_backend::CraneliftCompiler;
+use wasmer_runtime::{compile_with, Module};
+
+pub fn compile(code: &[u8]) -> Module {
+    compile_with(code, &CraneliftCompiler::new()).unwrap()
+}

--- a/lib/vm/src/backends/mod.rs
+++ b/lib/vm/src/backends/mod.rs
@@ -1,3 +1,3 @@
 mod cranelift;
 
-pub use cranelift::compile;
+pub use cranelift::{backend, compile};

--- a/lib/vm/src/backends/mod.rs
+++ b/lib/vm/src/backends/mod.rs
@@ -1,0 +1,3 @@
+mod cranelift;
+
+pub use cranelift::compile;

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -45,7 +45,7 @@ impl Cache {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     use crate::calls::{call_handle, call_init};
     use cosmwasm::types::{coin, mock_params};
@@ -54,7 +54,7 @@ mod test {
 
     #[test]
     fn init_cached_contract() {
-        let tmp_dir = TempDir::new("comswasm_cache_test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
         let mut cache = Cache::new(tmp_dir.path().to_str().unwrap());
         let id = cache.save_wasm(CONTRACT).unwrap();
         let mut instance = cache.get_instance(&id).unwrap();
@@ -71,7 +71,7 @@ mod test {
 
     #[test]
     fn run_cached_contract() {
-        let tmp_dir = TempDir::new("comswasm_cache_test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
         let mut cache = Cache::new(tmp_dir.path().to_str().unwrap());
         let id = cache.save_wasm(CONTRACT).unwrap();
         let mut instance = cache.get_instance(&id).unwrap();

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -3,30 +3,37 @@ use std::path::PathBuf;
 
 use failure::Error;
 
+use crate::modules::FileSystemCache;
 use crate::wasm_store::{load, save};
 use crate::wasmer::{instantiate, Instance};
 
 pub struct Cache {
     wasm_path: PathBuf,
+    modules: FileSystemCache,
 }
 
 static WASM_DIR: &str = "wasm";
+static MODULES_DIR: &str = "modules";
 
 impl Cache {
     /// new stores the data for cache under base_dir
-    pub fn new<P: Into<PathBuf>>(base_dir: P) -> Self {
-        let wasm_path = base_dir.into().join(WASM_DIR);
+    pub unsafe fn new<P: Into<PathBuf>>(base_dir: P) -> Self {
+        let base = base_dir.into();
+        let wasm_path = base.join(WASM_DIR);
         create_dir_all(&wasm_path).unwrap();
-        Cache { wasm_path }
+        let modules = FileSystemCache::new(base.join(MODULES_DIR)).unwrap();
+        Cache { modules, wasm_path }
     }
 }
 
 impl Cache {
     pub fn save_wasm(&mut self, wasm: &[u8]) -> Result<Vec<u8>, Error> {
+        // TODO: store modules
         save(&self.wasm_path, wasm)
     }
 
     pub fn load_wasm(&self, id: &[u8]) -> Result<Vec<u8>, Error> {
+        // TODO: load modules cache if present
         load(&self.wasm_path, id)
     }
 
@@ -51,7 +58,7 @@ mod test {
     #[test]
     fn init_cached_contract() {
         let tmp_dir = TempDir::new().unwrap();
-        let mut cache = Cache::new(tmp_dir.path().to_str().unwrap());
+        let mut cache = unsafe { Cache::new(tmp_dir.path().to_str().unwrap()) };
         let id = cache.save_wasm(CONTRACT).unwrap();
         let mut instance = cache.get_instance(&id).unwrap();
 
@@ -68,7 +75,7 @@ mod test {
     #[test]
     fn run_cached_contract() {
         let tmp_dir = TempDir::new().unwrap();
-        let mut cache = Cache::new(tmp_dir.path().to_str().unwrap());
+        let mut cache = unsafe { Cache::new(tmp_dir.path().to_str().unwrap()) };
         let id = cache.save_wasm(CONTRACT).unwrap();
         let mut instance = cache.get_instance(&id).unwrap();
 

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -6,7 +6,7 @@ use failure::{bail, Error};
 use crate::backends::{backend, compile};
 use crate::modules::{Cache, FileSystemCache, WasmHash};
 use crate::wasm_store::{load, save, wasm_hash};
-use crate::wasmer::{instantiate, Instance, mod_to_instance};
+use crate::wasmer::{instantiate, mod_to_instance, Instance};
 
 pub struct CosmCache {
     wasm_path: PathBuf,

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -1,37 +1,33 @@
-use std::path::{Path, PathBuf};
+use std::fs::create_dir_all;
+use std::path::PathBuf;
 
 use failure::Error;
 
-use crate::wasm_store::{ensure_dir, load, save};
+use crate::wasm_store::{load, save};
 use crate::wasmer::{instantiate, Instance};
 
 pub struct Cache {
-    wasm_dir: PathBuf,
+    wasm_path: PathBuf,
 }
 
 static WASM_DIR: &str = "wasm";
 
 impl Cache {
     /// new stores the data for cache under base_dir
-    pub fn new(base_dir: &str) -> Self {
-        let wasm_dir = Path::new(base_dir).join(WASM_DIR);
-        let cache = Cache { wasm_dir };
-        ensure_dir(cache.wasm_path()).unwrap();
-        cache
-    }
-
-    fn wasm_path(&self) -> &str {
-        self.wasm_dir.to_str().unwrap()
+    pub fn new<P: Into<PathBuf>>(base_dir: P) -> Self {
+        let wasm_path = base_dir.into().join(WASM_DIR);
+        create_dir_all(&wasm_path).unwrap();
+        Cache { wasm_path }
     }
 }
 
 impl Cache {
     pub fn save_wasm(&mut self, wasm: &[u8]) -> Result<Vec<u8>, Error> {
-        save(self.wasm_path(), wasm)
+        save(&self.wasm_path, wasm)
     }
 
     pub fn load_wasm(&self, id: &[u8]) -> Result<Vec<u8>, Error> {
-        load(self.wasm_path(), id)
+        load(&self.wasm_path, id)
     }
 
     /// get instance returns a wasmer Instance tied to a previously saved wasm

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -2,6 +2,7 @@ mod cache;
 mod calls;
 mod exports;
 mod memory;
+mod modules;
 mod wasm_store;
 mod wasmer;
 

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -1,3 +1,4 @@
+mod backends;
 mod cache;
 mod calls;
 mod exports;

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -7,7 +7,7 @@ mod modules;
 mod wasm_store;
 mod wasmer;
 
-pub use crate::cache::Cache;
+pub use crate::cache::CosmCache;
 pub use crate::calls::{call_handle, call_handle_raw, call_init, call_init_raw};
 pub use crate::memory::{allocate, read_memory};
 pub use crate::wasmer::{instantiate, with_storage};

--- a/lib/vm/src/modules.rs
+++ b/lib/vm/src/modules.rs
@@ -7,13 +7,15 @@ use std::{
     io::{self, Write},
     path::PathBuf,
 };
-use wasmer_runtime::Module;
 
+use wasmer_runtime::Module;
 use wasmer_runtime_core::cache::Error as CacheError;
 pub use wasmer_runtime_core::{
     backend::Backend,
     cache::{Artifact, Cache, WasmHash},
 };
+
+use crate::backends::backend;
 
 /// Representation of a directory that contains compiled wasm artifacts.
 ///
@@ -88,7 +90,7 @@ impl Cache for FileSystemCache {
     type StoreError = CacheError;
 
     fn load(&self, key: WasmHash) -> Result<Module, CacheError> {
-        self.load_with_backend(key, Backend::default())
+        self.load_with_backend(key, backend())
     }
 
     fn load_with_backend(&self, key: WasmHash, backend: Backend) -> Result<Module, CacheError> {

--- a/lib/vm/src/modules.rs
+++ b/lib/vm/src/modules.rs
@@ -1,13 +1,13 @@
 // copied from https://github.com/wasmerio/wasmer/blob/0.8.0/lib/runtime/src/cache.rs
 // with some minor modifications
 
-use wasmer_runtime::Module;
 use memmap::Mmap;
 use std::{
     fs::{create_dir_all, File},
     io::{self, Write},
     path::PathBuf,
 };
+use wasmer_runtime::Module;
 
 use wasmer_runtime_core::cache::Error as CacheError;
 pub use wasmer_runtime_core::{
@@ -136,8 +136,8 @@ mod tests {
 
     #[test]
     fn test_file_system_cache_run() {
-        use wasmer_runtime::{compile, imports, Func};
         use wabt::wat2wasm;
+        use wasmer_runtime::{compile, imports, Func};
 
         static WAT: &'static str = r#"
             (module

--- a/lib/vm/src/modules.rs
+++ b/lib/vm/src/modules.rs
@@ -1,0 +1,179 @@
+// copied from https://github.com/wasmerio/wasmer/blob/0.8.0/lib/runtime/src/cache.rs
+// with some minor modifications
+
+use wasmer_runtime::Module;
+use memmap::Mmap;
+use std::{
+    fs::{create_dir_all, File},
+    io::{self, Write},
+    path::PathBuf,
+};
+
+use wasmer_runtime_core::cache::Error as CacheError;
+pub use wasmer_runtime_core::{
+    backend::Backend,
+    cache::{Artifact, Cache, WasmHash},
+};
+
+/// Representation of a directory that contains compiled wasm artifacts.
+///
+/// The `FileSystemCache` type implements the [`Cache`] trait, which allows it to be used
+/// generically when some sort of cache is required.
+///
+/// [`Cache`]: trait.Cache.html
+///
+/// # Usage:
+///
+/// ```rust
+/// use wasmer_runtime::cache::{Cache, FileSystemCache, WasmHash};
+///
+/// # use wasmer_runtime::{Module, error::CacheError};
+/// fn store_module(module: Module) -> Result<Module, CacheError> {
+///     // Create a new file system cache.
+///     // This is unsafe because we can't ensure that the artifact wasn't
+///     // corrupted or tampered with.
+///     let mut fs_cache = unsafe { FileSystemCache::new("some/directory/goes/here")? };
+///     // Compute a key for a given WebAssembly binary
+///     let key = WasmHash::generate(&[]);
+///     // Store a module into the cache given a key
+///     fs_cache.store(key, module.clone())?;
+///     Ok(module)
+/// }
+/// ```
+pub struct FileSystemCache {
+    path: PathBuf,
+}
+
+impl FileSystemCache {
+    /// Construct a new `FileSystemCache` around the specified directory.
+    /// The contents of the cache are stored in sub-versioned directories.
+    ///
+    /// # Note:
+    /// This method is unsafe because there's no way to ensure the artifacts
+    /// stored in this cache haven't been corrupted or tampered with.
+    pub unsafe fn new<P: Into<PathBuf>>(path: P) -> io::Result<Self> {
+        let path: PathBuf = path.into();
+        if path.exists() {
+            let metadata = path.metadata()?;
+            if metadata.is_dir() {
+                if !metadata.permissions().readonly() {
+                    Ok(Self { path })
+                } else {
+                    // This directory is readonly.
+                    Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("the supplied path is readonly: {}", path.display()),
+                    ))
+                }
+            } else {
+                // This path points to a file.
+                Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "the supplied path already points to a file: {}",
+                        path.display()
+                    ),
+                ))
+            }
+        } else {
+            // Create the directory and any parent directories if they don't yet exist.
+            create_dir_all(&path)?;
+            Ok(Self { path })
+        }
+    }
+}
+
+impl Cache for FileSystemCache {
+    type LoadError = CacheError;
+    type StoreError = CacheError;
+
+    fn load(&self, key: WasmHash) -> Result<Module, CacheError> {
+        self.load_with_backend(key, Backend::default())
+    }
+
+    fn load_with_backend(&self, key: WasmHash, backend: Backend) -> Result<Module, CacheError> {
+        let filename = key.encode();
+        let mut new_path_buf = self.path.clone();
+        new_path_buf.push(backend.to_string());
+        new_path_buf.push(filename);
+        let file = File::open(new_path_buf)?;
+        let mmap = unsafe { Mmap::map(&file)? };
+
+        let serialized_cache = Artifact::deserialize(&mmap[..])?;
+        unsafe {
+            wasmer_runtime_core::load_cache_with(
+                serialized_cache,
+                wasmer_runtime::compiler_for_backend(backend)
+                    .ok_or_else(|| CacheError::UnsupportedBackend(backend))?
+                    .as_ref(),
+            )
+        }
+    }
+
+    fn store(&mut self, key: WasmHash, module: Module) -> Result<(), CacheError> {
+        let filename = key.encode();
+        let backend_str = module.info().backend.to_string();
+        let mut new_path_buf = self.path.clone();
+        new_path_buf.push(backend_str);
+
+        let serialized_cache = module.cache()?;
+        let buffer = serialized_cache.serialize()?;
+
+        std::fs::create_dir_all(&new_path_buf)?;
+        new_path_buf.push(filename);
+        let mut file = File::create(new_path_buf)?;
+        file.write_all(&buffer)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, not(feature = "singlepass")))]
+mod tests {
+
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_file_system_cache_run() {
+        use wasmer_runtime::{compile, imports, Func};
+        use wabt::wat2wasm;
+
+        static WAT: &'static str = r#"
+            (module
+              (type $t0 (func (param i32) (result i32)))
+              (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
+                get_local $p0
+                i32.const 1
+                i32.add))
+        "#;
+
+        let wasm = wat2wasm(WAT).unwrap();
+
+        let module = compile(&wasm).unwrap();
+
+        let cache_dir = env::temp_dir();
+        println!("test temp_dir {:?}", cache_dir);
+
+        let mut fs_cache = unsafe {
+            FileSystemCache::new(cache_dir)
+                .map_err(|e| format!("Cache error: {:?}", e))
+                .unwrap()
+        };
+        // store module
+        let key = WasmHash::generate(&wasm);
+        fs_cache.store(key, module.clone()).unwrap();
+
+        // load module
+        let cached_module = fs_cache.load(key).unwrap();
+
+        let import_object = imports! {};
+        let instance = cached_module.instantiate(&import_object).unwrap();
+        let add_one: Func<i32, i32> = instance.func("add_one").unwrap();
+
+        let value = add_one.call(42).unwrap();
+
+        // verify it works
+        assert_eq!(value, 43);
+    }
+}

--- a/lib/vm/src/wasm_store.rs
+++ b/lib/vm/src/wasm_store.rs
@@ -43,11 +43,11 @@ pub fn load(dir: &str, id: &[u8]) -> Result<Vec<u8>, Error> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[test]
     fn save_and_load() {
-        let tmp_dir = TempDir::new("comswasm_vm_test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
         let code = vec![12u8; 17];
         let id = save(path, &code).unwrap();
@@ -59,7 +59,7 @@ mod test {
 
     #[test]
     fn fails_on_non_existent_dir() {
-        let tmp_dir = TempDir::new("comswasm_vm_test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
         let path = tmp_dir.path().join("something");
         let code = vec![12u8; 17];
         let res = save(path.to_str().unwrap(), &code);
@@ -68,7 +68,7 @@ mod test {
 
     #[test]
     fn ensure_dir_prepares_space() {
-        let tmp_dir = TempDir::new("comswasm_vm_test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
         let path = tmp_dir.path().join("something");
         let dir = path.to_str().unwrap();
         ensure_dir(dir).unwrap();
@@ -82,7 +82,7 @@ mod test {
 
     #[test]
     fn file_already_exists() {
-        let tmp_dir = TempDir::new("comswasm_vm_test").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
         let code = vec![12u8; 17];
         let id = save(path, &code).unwrap();

--- a/lib/vm/src/wasm_store.rs
+++ b/lib/vm/src/wasm_store.rs
@@ -5,12 +5,16 @@ use std::path::PathBuf;
 use failure::Error;
 use sha2::{Digest, Sha256};
 
+pub fn wasm_hash(wasm: &[u8]) -> Vec<u8> {
+    Sha256::digest(wasm).to_vec()
+}
+
 /// save stores the wasm code in the given directory and returns an ID for lookup.
 /// It will create the directory if it doesn't exist.
 /// If the file already exists, it will return an error.
 pub fn save<P: Into<PathBuf>>(dir: P, wasm: &[u8]) -> Result<Vec<u8>, Error> {
     // calculate filename
-    let id = Sha256::digest(wasm).to_vec();
+    let id = wasm_hash(wasm);
     let filename = hex::encode(&id);
     let filepath = dir.into().join(&filename);
 

--- a/lib/vm/src/wasmer.rs
+++ b/lib/vm/src/wasmer.rs
@@ -1,12 +1,17 @@
 pub use wasmer_runtime::{Func, Instance};
 
-use wasmer_runtime::{func, imports};
+use wasmer_runtime::{func, imports, Module};
 
 use crate::backends::compile;
 use crate::exports::{do_read, do_write, setup_context, with_storage_from_context};
 use cosmwasm::mock::MockStorage;
 
 pub fn instantiate(code: &[u8]) -> Instance {
+    let module = compile(code);
+    mod_to_instance(&module)
+}
+
+pub fn mod_to_instance(module: &Module) -> Instance {
     let import_obj = imports! {
         || { setup_context() },
         "env" => {
@@ -19,7 +24,6 @@ pub fn instantiate(code: &[u8]) -> Instance {
     // TODO: we unwrap rather than Result as:
     //   the trait `std::marker::Send` is not implemented for `(dyn std::any::Any + 'static)`
     // convert from wasmer error to failure error....
-    let module = compile(code);
     module.instantiate(&import_obj).unwrap()
 }
 

--- a/lib/vm/src/wasmer.rs
+++ b/lib/vm/src/wasmer.rs
@@ -1,8 +1,8 @@
 pub use wasmer_runtime::{Func, Instance};
 
-use wasmer_clif_backend::CraneliftCompiler;
-use wasmer_runtime::{compile_with, func, imports};
+use wasmer_runtime::{func, imports};
 
+use crate::backends::compile;
 use crate::exports::{do_read, do_write, setup_context, with_storage_from_context};
 use cosmwasm::mock::MockStorage;
 
@@ -19,7 +19,7 @@ pub fn instantiate(code: &[u8]) -> Instance {
     // TODO: we unwrap rather than Result as:
     //   the trait `std::marker::Send` is not implemented for `(dyn std::any::Any + 'static)`
     // convert from wasmer error to failure error....
-    let module = compile_with(code, &CraneliftCompiler::new()).unwrap();
+    let module = compile(code);
     module.instantiate(&import_obj).unwrap()
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,8 +54,6 @@ pub enum CosmosMsg {
     },
 }
 
-// TODO: clean this up - let's us a normal result type??? or at least normal terms
-
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ContractResult {


### PR DESCRIPTION
Closes #23 
Closes #25 

Use the FileSystemCache from wasmer to store Modules/Artifacts and do a pre-compile step when first saving the wasm.