### PR TITLE
Configure storage

### DIFF
--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -78,6 +78,7 @@ mod test {
 
     use crate::calls::{call_handle, call_init};
     use cosmwasm::types::{coin, mock_params};
+    use cosmwasm::mock::MockStorage;
 
     static CONTRACT: &[u8] = include_bytes!("../testdata/contract.wasm");
 
@@ -86,7 +87,8 @@ mod test {
         let tmp_dir = TempDir::new().unwrap();
         let mut cache = unsafe { CosmCache::new(tmp_dir.path().to_str().unwrap()) };
         let id = cache.save_wasm(CONTRACT).unwrap();
-        let mut instance = cache.get_instance(&id).unwrap();
+        let storage = MockStorage::new();
+        let mut instance = cache.get_instance(&id, storage).unwrap();
 
         // run contract
         let params = mock_params("creator", &coin("1000", "earth"), &[]);
@@ -103,7 +105,8 @@ mod test {
         let tmp_dir = TempDir::new().unwrap();
         let mut cache = unsafe { CosmCache::new(tmp_dir.path().to_str().unwrap()) };
         let id = cache.save_wasm(CONTRACT).unwrap();
-        let mut instance = cache.get_instance(&id).unwrap();
+        let storage = MockStorage::new();
+        let mut instance = cache.get_instance(&id, storage).unwrap();
 
         // init contract
         let params = mock_params("creator", &coin("1000", "earth"), &[]);

--- a/lib/vm/src/exports.rs
+++ b/lib/vm/src/exports.rs
@@ -3,46 +3,46 @@ use std::mem;
 
 use wasmer_runtime::Ctx;
 
-use cosmwasm::mock::{MockStorage, Storage};
+use cosmwasm::storage::Storage;
 
 use crate::memory::{read_memory, write_memory};
 
 /*** mocks to stub out actually db writes as extern "C" ***/
 
-pub fn do_read(ctx: &mut Ctx, key_ptr: u32, val_ptr: u32) -> i32 {
+pub fn do_read<T: Storage>(ctx: &mut Ctx, key_ptr: u32, val_ptr: u32) -> i32 {
     let key = read_memory(ctx, key_ptr);
     let mut value: Option<Vec<u8>> = None;
-    with_storage_from_context(ctx, |store| value = store.get(&key));
+    with_storage_from_context::<T>(ctx, |store| value = store.get(&key));
     match value {
         Some(buf) => write_memory(ctx, val_ptr, &buf),
         None => 0,
     }
 }
 
-pub fn do_write(ctx: &mut Ctx, key: u32, value: u32) {
+pub fn do_write<T: Storage>(ctx: &mut Ctx, key: u32, value: u32) {
     let key = read_memory(ctx, key);
     let value = read_memory(ctx, value);
-    with_storage_from_context(ctx, |store| store.set(&key, &value));
+    with_storage_from_context::<T>(ctx, |store| store.set(&key, &value));
 }
 
 /*** context data ****/
 
-pub fn setup_context() -> (*mut c_void, fn(*mut c_void)) {
-    (create_unmanaged_storage(), destroy_unmanaged_storage)
+pub fn setup_context<T: Storage>(storage: T) -> (*mut c_void, fn(*mut c_void)) {
+    (create_unmanaged_storage(storage), destroy_unmanaged_storage::<T>)
 }
 
-fn create_unmanaged_storage() -> *mut c_void {
-    let state = Box::new(MockStorage::new());
+fn create_unmanaged_storage<T: Storage>(storage: T) -> *mut c_void {
+    let state = Box::new(storage);
     Box::into_raw(state) as *mut c_void
 }
 
-fn destroy_unmanaged_storage(ptr: *mut c_void) {
+fn destroy_unmanaged_storage<T: Storage>(ptr: *mut c_void) {
     // auto-dropped with scope
-    let _ = unsafe { Box::from_raw(ptr as *mut MockStorage) };
+    let _ = unsafe { Box::from_raw(ptr as *mut T) };
 }
 
-pub fn with_storage_from_context<F: FnMut(&mut MockStorage)>(ctx: &Ctx, mut func: F) {
-    let mut b = unsafe { Box::from_raw(ctx.data as *mut MockStorage) };
+pub fn with_storage_from_context<T: Storage, F: FnMut(&mut T)>(ctx: &Ctx, mut func: F) {
+    let mut b = unsafe { Box::from_raw(ctx.data as *mut T) };
     func(b.as_mut());
     mem::forget(b); // we do this to avoid cleanup
 }

--- a/lib/vm/src/exports.rs
+++ b/lib/vm/src/exports.rs
@@ -12,7 +12,7 @@ use crate::memory::{read_memory, write_memory};
 pub fn do_read<T: Storage>(ctx: &mut Ctx, key_ptr: u32, val_ptr: u32) -> i32 {
     let key = read_memory(ctx, key_ptr);
     let mut value: Option<Vec<u8>> = None;
-    with_storage_from_context::<T>(ctx, |store| value = store.get(&key));
+    with_storage_from_context(ctx, |store: &mut T| value = store.get(&key));
     match value {
         Some(buf) => write_memory(ctx, val_ptr, &buf),
         None => 0,
@@ -22,7 +22,7 @@ pub fn do_read<T: Storage>(ctx: &mut Ctx, key_ptr: u32, val_ptr: u32) -> i32 {
 pub fn do_write<T: Storage>(ctx: &mut Ctx, key: u32, value: u32) {
     let key = read_memory(ctx, key);
     let value = read_memory(ctx, value);
-    with_storage_from_context::<T>(ctx, |store| store.set(&key, &value));
+    with_storage_from_context(ctx, |store: &mut T| store.set(&key, &value));
 }
 
 /*** context data ****/

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -14,6 +14,7 @@ extern "C" {
     fn c_write(key: *const c_void, value: *mut c_void);
 }
 
+#[derive(Clone)]
 pub struct ExternalStorage {}
 
 impl ExternalStorage {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 pub use crate::storage::Storage;
 
+#[derive(Clone)]
 pub struct MockStorage {
     data: HashMap<Vec<u8>, Vec<u8>>,
 }


### PR DESCRIPTION
Closes #39 

Convert all storage methods in  cosmwasm-vm to use generics, rather than MockStorage. 