### PR TITLE
Simplify context data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cosmwasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "cosmwasm 0.2.0",
+ "cosmwasm 0.3.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cosmwasm 0.3.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Wasm smart contracts for Cosmos"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -243,7 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cosmwasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "cosmwasm 0.2.0",
+ "cosmwasm 0.3.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -456,10 +456,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hackatom"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
- "cosmwasm 0.2.0",
- "cosmwasm-vm 0.2.0",
+ "cosmwasm 0.3.0",
+ "cosmwasm-vm 0.3.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cosmwasm 0.3.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -459,7 +459,7 @@ name = "hackatom"
 version = "0.3.0"
 dependencies = [
  "cosmwasm 0.3.0",
- "cosmwasm-vm 0.3.0",
+ "cosmwasm-vm 0.3.1",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -36,4 +36,4 @@ failure = "0.1.5"
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
-cosmwasm-vm = { path = "../../lib/vm", version = "0.3.0" }
+cosmwasm-vm = { path = "../../lib/vm", version = "0.3.1" }

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hackatom"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 
@@ -29,7 +29,7 @@ default = [ "integration" ]
 integration = [ ]
 
 [dependencies]
-cosmwasm = { path = "../..", version = "0.2.0" }
+cosmwasm = { path = "../..", version = "0.3.0" }
 serde = { version = "1.0.60", default-features = false, features = ["derive"] }
 failure = "0.1.5"
 # needed for wasm-pack build process

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -36,4 +36,4 @@ failure = "0.1.5"
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
-cosmwasm-vm = { path = "../../lib/vm", version = "0.2.0" }
+cosmwasm-vm = { path = "../../lib/vm", version = "0.3.0" }

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-vm"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "VM bindings to run cosmwams contracts"

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-vm"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "VM bindings to run cosmwams contracts"
@@ -12,7 +12,7 @@ circle-ci = { repository = "confio/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-cosmwasm = { path = "../..", version = "0.2.0" }
+cosmwasm = { path = "../..", version = "0.3.0" }
 wasmer-runtime = "0.8.0"
 wasmer-runtime-core = "0.8.0"
 wasmer-clif-backend = "0.8.0"

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -14,10 +14,7 @@ use crate::wasm_store::{load, save, wasm_hash};
 static WASM_DIR: &str = "wasm";
 static MODULES_DIR: &str = "modules";
 
-pub struct CosmCache<T>
-where
-    T: Storage + Send + Sync + Clone + 'static,
-{
+pub struct CosmCache<T: Storage + 'static> {
     wasm_path: PathBuf,
     modules: FileSystemCache,
     instances: Option<LruCache<WasmHash, Instance<T>>>,
@@ -25,7 +22,7 @@ where
 
 impl<T> CosmCache<T>
 where
-    T: Storage + Send + Sync + Clone + 'static,
+    T: Storage + 'static,
 {
     /// new stores the data for cache under base_dir
     pub unsafe fn new<P: Into<PathBuf>>(base_dir: P, cache_size: usize) -> Self {

--- a/lib/vm/src/calls.rs
+++ b/lib/vm/src/calls.rs
@@ -6,65 +6,50 @@ use cosmwasm::types::{ContractResult, Params};
 
 use crate::instance::{Func, Instance};
 
-pub fn call_init<T>(
+pub fn call_init<T: Storage + 'static>(
     instance: &mut Instance<T>,
     params: &Params,
     msg: &[u8],
-) -> Result<ContractResult, Error>
-where
-    T: Storage + Send + Sync + Clone + 'static,
-{
+) -> Result<ContractResult, Error> {
     let params = to_vec(params)?;
     let data = call_init_raw(instance, &params, msg)?;
     let res: ContractResult = from_slice(&data)?;
     Ok(res)
 }
 
-pub fn call_handle<T>(
+pub fn call_handle<T: Storage + 'static>(
     instance: &mut Instance<T>,
     params: &Params,
     msg: &[u8],
-) -> Result<ContractResult, Error>
-where
-    T: Storage + Send + Sync + Clone + 'static,
-{
+) -> Result<ContractResult, Error> {
     let params = to_vec(params)?;
     let data = call_handle_raw(instance, &params, msg)?;
     let res: ContractResult = from_slice(&data)?;
     Ok(res)
 }
 
-pub fn call_init_raw<T>(
+pub fn call_init_raw<T: Storage + 'static>(
     instance: &mut Instance<T>,
     params: &[u8],
     msg: &[u8],
-) -> Result<Vec<u8>, Error>
-where
-    T: Storage + Send + Sync + Clone + 'static,
-{
+) -> Result<Vec<u8>, Error> {
     call_raw(instance, "init", params, msg)
 }
 
-pub fn call_handle_raw<T>(
+pub fn call_handle_raw<T: Storage + 'static>(
     instance: &mut Instance<T>,
     params: &[u8],
     msg: &[u8],
-) -> Result<Vec<u8>, Error>
-where
-    T: Storage + Send + Sync + Clone + 'static,
-{
+) -> Result<Vec<u8>, Error> {
     call_raw(instance, "handle", params, msg)
 }
 
-fn call_raw<T>(
+fn call_raw<T: Storage + 'static>(
     instance: &mut Instance<T>,
     name: &str,
     params: &[u8],
     msg: &[u8],
-) -> Result<Vec<u8>, Error>
-where
-    T: Storage + Send + Sync + Clone + 'static,
-{
+) -> Result<Vec<u8>, Error> {
     let param_offset = instance.allocate(params);
     let msg_offset = instance.allocate(msg);
 

--- a/lib/vm/src/context.rs
+++ b/lib/vm/src/context.rs
@@ -40,9 +40,7 @@ pub fn setup_context<T: Storage>() -> (*mut c_void, fn(*mut c_void)) {
 }
 
 fn create_unmanaged_storage<T: Storage>() -> *mut c_void {
-    let data = ContextData::<T> {
-        data: None,
-    };
+    let data = ContextData::<T> { data: None };
     let state = Box::new(data);
     Box::into_raw(state) as *mut c_void
 }

--- a/lib/vm/src/context.rs
+++ b/lib/vm/src/context.rs
@@ -32,16 +32,16 @@ struct ContextData<T: Storage> {
     data: Option<T>,
 }
 
-pub fn setup_context<T: Storage>(storage: T) -> (*mut c_void, fn(*mut c_void)) {
+pub fn setup_context<T: Storage>() -> (*mut c_void, fn(*mut c_void)) {
     (
-        create_unmanaged_storage(storage),
+        create_unmanaged_storage::<T>(),
         destroy_unmanaged_storage::<T>,
     )
 }
 
-fn create_unmanaged_storage<T: Storage>(storage: T) -> *mut c_void {
-    let data = ContextData {
-        data: Some(storage),
+fn create_unmanaged_storage<T: Storage>() -> *mut c_void {
+    let data = ContextData::<T> {
+        data: None,
     };
     let state = Box::new(data);
     Box::into_raw(state) as *mut c_void

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -14,17 +14,14 @@ use crate::context::{
 use crate::memory::{read_memory, write_memory};
 use cosmwasm::storage::Storage;
 
-pub struct Instance<T>
-where
-    T: Storage + Send + Sync + Clone + 'static,
-{
+pub struct Instance<T: Storage + 'static> {
     instance: wasmer_runtime::Instance,
     storage: PhantomData<T>,
 }
 
 impl<T> Instance<T>
 where
-    T: Storage + Send + Sync + Clone + 'static,
+    T: Storage + 'static,
 {
     pub fn from_code(code: &[u8], storage: T) -> Instance<T> {
         let module = compile(code);


### PR DESCRIPTION
Don't pass the Storage into the `imports!` macro and just use `leave_storage`. This allows us to remove the requirement of `Sync + Send + Clone` traits.