### PR TITLE
Single pass with gas metering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ workflows:
   test:
     jobs:
       - base
-      - hackatom
+      - singlepass_vm
+      - cranelift_vm
 
 jobs:
   base:
@@ -20,20 +21,81 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - v4-cargo-cache-base-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Build all targets (including workspaces)
-          command: cargo build --all --locked
+          command: cargo build --locked
       - run:
           name: Run all tests (including workspaces)
-          command: cargo test --all --locked
+          command: cargo test --locked
       - save_cache:
           paths:
             - /usr/local/cargo/registry
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: v4-cargo-cache-base-{{ arch }}-{{ checksum "Cargo.lock" }}
+
+  singlepass_vm:
+    docker:
+      - image: rustlang/rust:nightly
+    steps:
+      - checkout
+      - run:
+          name: Install CMAKE
+          command: 'apt-get update && apt-get install -y cmake'
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - restore_cache:
+          keys:
+            - v4-cargo-cache-singlepass-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Build all targets (including workspaces)
+          working_directory: ~/project/lib/vm
+          command: cargo build --locked
+      - run:
+          name: Run all tests (including workspaces)
+          working_directory: ~/project/lib/vm
+          command: cargo test --locked
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: v4-cargo-cache-singlepass-{{ arch }}-{{ checksum "Cargo.lock" }}
+
+  cranelift_vm:
+    docker:
+      - image: rust:1.37
+    steps:
+      - checkout
+      - run:
+          name: Install CMAKE
+          command: 'apt-get update && apt-get install -y cmake'
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - restore_cache:
+          keys:
+            - v4-cargo-cache-cranelift-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Build all targets (including workspaces)
+          working_directory: ~/project/lib/vm
+          command: cargo build --locked --no-default-features --features cranelift,default-cranelift
+      - run:
+          name: Run all tests (including workspaces)
+          working_directory: ~/project/lib/vm
+          command: cargo test --locked --no-default-features --features cranelift,default-cranelift
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: v4-cargo-cache-cranelift-{{ arch }}-{{ checksum "Cargo.lock" }}
+
   hackatom:
     docker:
       - image: rust:1.37
@@ -46,7 +108,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - v4-cargo-cache-hackatom-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -68,4 +130,4 @@ jobs:
             - target/wasm32-unknown-unknown/release/.fingerprint
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
-          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: v4-cargo-cache-hackatom-{{ arch }}-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
       - base
       - singlepass_vm
       - cranelift_vm
+      - hackatom
 
 jobs:
   base:
@@ -98,7 +99,8 @@ jobs:
 
   hackatom:
     docker:
-      - image: rust:1.37
+      # this will use singlepass by default, so we will need nightly
+      - image: rustlang/rust:nightly
     working_directory: ~/cosmwasm/contracts/hackatom
     steps:
       - checkout:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-middleware-common 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-singlepass-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1184,6 +1185,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-middleware-common"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasmer-runtime"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1459,7 @@ dependencies = [
 "checksum wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67e7a747aff0449ab4639e6f1f3c5ec5a3a1099685d34fcabf4628b5b031944c"
 "checksum wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf2f552a9c1fda0555087170424bd8fedc63a079a97bb5638a4ef9b0d9656aa"
 "checksum wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0073b512e1af5948d34be7944b74c747bbe735ccff2e2f28c26ed4c90725de8e"
+"checksum wasmer-middleware-common 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5af520a6781d6561bfb2be6d451ac290664996021053e8f061b5f75085ff0520"
 "checksum wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b1312944941d659634a65e0376fe2af62951af15443c8b7959cfcb0236bae0"
 "checksum wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25ae12db70ebb4c15afacadaaa8b14d6583e5e7ca21323cf785627b8499e3add"
 "checksum wasmer-singlepass-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f60d77696e80e6d5baf58fc9d6a6affcc308f296caab065cada53ec70b72d221"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-singlepass-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -366,6 +367,30 @@ dependencies = [
 name = "doc-comment"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dynasm"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "either"
@@ -556,6 +581,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memmap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -609,6 +643,14 @@ dependencies = [
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "owning_ref"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "page_size"
@@ -938,6 +980,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1019,11 @@ dependencies = [
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "target-lexicon"
@@ -1170,6 +1222,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-singlepass-backend"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dynasm 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dynasmrt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasmer-win-exception-handler"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1350,8 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
+"checksum dynasm 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f36d49ab6f8ecc642d2c6ee10fda04ba68003ef0277300866745cdde160e6b40"
+"checksum dynasmrt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c408a211e7f5762829f5e46bdff0c14bc3b1517a21a4bb781c716bf88b0c68"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
@@ -1307,6 +1377,7 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e542a8a0a1309ceed0614dbb910658c118f4ff40b0ed31a1bf77a869a5a1853"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
@@ -1314,6 +1385,7 @@ dependencies = [
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f89ef58b3d32420dbd1a43d2f38ae92f6239ef12bb556ab09ca55445f5a67242"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
@@ -1354,10 +1426,12 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d0bf93d08d6a44363b47d737f1f5bebbf5e6a1eaaa3d4c128ceeaca6b718292"
 "checksum snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624e94bd38e471f67883b467711e7a7ad7dbe284f5fb7e661dc8a671fc5b26a0"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
+"checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7975cb2c6f37d77b190bc5004a2bb015971464756fde9514651a525ada2a741a"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
@@ -1378,6 +1452,7 @@ dependencies = [
 "checksum wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0073b512e1af5948d34be7944b74c747bbe735ccff2e2f28c26ed4c90725de8e"
 "checksum wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b1312944941d659634a65e0376fe2af62951af15443c8b7959cfcb0236bae0"
 "checksum wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25ae12db70ebb4c15afacadaaa8b14d6583e5e7ca21323cf785627b8499e3add"
+"checksum wasmer-singlepass-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f60d77696e80e6d5baf58fc9d6a6affcc308f296caab065cada53ec70b72d221"
 "checksum wasmer-win-exception-handler 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1e84b6f4fb0bd59a3db906c99aa956d5022e7fdb8e34570dbb904cca36f5a3"
 "checksum wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5083b449454f7de0b15f131eee17de54b5a71dcb9adcf11df2b2f78fad0cd82"
 "checksum which 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "240a31163872f7e8e49f35b42b58485e35355b07eb009d9f3686733541339a69"

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -260,9 +260,10 @@ dependencies = [
  "lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-middleware-common 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-singlepass-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -369,6 +370,30 @@ dependencies = [
 name = "doc-comment"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dynasm"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "either"
@@ -565,6 +590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memmap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -618,6 +652,14 @@ dependencies = [
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "owning_ref"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "page_size"
@@ -939,6 +981,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1020,11 @@ dependencies = [
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "target-lexicon"
@@ -1148,6 +1200,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-middleware-common"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasmer-runtime"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1243,22 @@ dependencies = [
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasmer-singlepass-backend"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dynasm 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dynasmrt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1299,6 +1375,8 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
+"checksum dynasm 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f36d49ab6f8ecc642d2c6ee10fda04ba68003ef0277300866745cdde160e6b40"
+"checksum dynasmrt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c408a211e7f5762829f5e46bdff0c14bc3b1517a21a4bb781c716bf88b0c68"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
@@ -1323,6 +1401,7 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e542a8a0a1309ceed0614dbb910658c118f4ff40b0ed31a1bf77a869a5a1853"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
@@ -1330,6 +1409,7 @@ dependencies = [
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f89ef58b3d32420dbd1a43d2f38ae92f6239ef12bb556ab09ca55445f5a67242"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
@@ -1369,10 +1449,12 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d0bf93d08d6a44363b47d737f1f5bebbf5e6a1eaaa3d4c128ceeaca6b718292"
 "checksum snafu-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624e94bd38e471f67883b467711e7a7ad7dbe284f5fb7e661dc8a671fc5b26a0"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
+"checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7975cb2c6f37d77b190bc5004a2bb015971464756fde9514651a525ada2a741a"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
@@ -1393,8 +1475,10 @@ dependencies = [
 "checksum wasmer-clif-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67e7a747aff0449ab4639e6f1f3c5ec5a3a1099685d34fcabf4628b5b031944c"
 "checksum wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf2f552a9c1fda0555087170424bd8fedc63a079a97bb5638a4ef9b0d9656aa"
 "checksum wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0073b512e1af5948d34be7944b74c747bbe735ccff2e2f28c26ed4c90725de8e"
+"checksum wasmer-middleware-common 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5af520a6781d6561bfb2be6d451ac290664996021053e8f061b5f75085ff0520"
 "checksum wasmer-runtime 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b1312944941d659634a65e0376fe2af62951af15443c8b7959cfcb0236bae0"
 "checksum wasmer-runtime-core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25ae12db70ebb4c15afacadaaa8b14d6583e5e7ca21323cf785627b8499e3add"
+"checksum wasmer-singlepass-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f60d77696e80e6d5baf58fc9d6a6affcc308f296caab065cada53ec70b72d221"
 "checksum wasmer-win-exception-handler 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1e84b6f4fb0bd59a3db906c99aa956d5022e7fdb8e34570dbb904cca36f5a3"
 "checksum wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5083b449454f7de0b15f131eee17de54b5a71dcb9adcf11df2b2f78fad0cd82"
 "checksum which 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "240a31163872f7e8e49f35b42b58485e35355b07eb009d9f3686733541339a69"

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -24,6 +24,7 @@ default-singlepass = []
 cosmwasm = { path = "../..", version = "0.3.0" }
 wasmer-runtime = "0.8.0"
 wasmer-runtime-core = "0.8.0"
+wasmer-middleware-common = "0.8.0"
 wasmer-clif-backend = {version = "0.8.0", optional = true }
 wasmer-singlepass-backend = {version = "0.8.0", optional = true }
 failure = "0.1.5"

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -11,11 +11,21 @@ license = "Apache-2.0"
 circle-ci = { repository = "confio/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
+[features]
+# select which backends are enabled (multiple possible)
+# default selects which is re-exported in backends/mod.rs (only one possible)
+default = ["singlepass", "default-singlepass"]
+cranelift = ["wasmer-clif-backend"]
+singlepass = ["wasmer-singlepass-backend"]
+default-cranelift = []
+default-singlepass = []
+
 [dependencies]
 cosmwasm = { path = "../..", version = "0.3.0" }
 wasmer-runtime = "0.8.0"
 wasmer-runtime-core = "0.8.0"
-wasmer-clif-backend = "0.8.0"
+wasmer-clif-backend = {version = "0.8.0", optional = true }
+wasmer-singlepass-backend = {version = "0.8.0", optional = true }
 failure = "0.1.5"
 sha2 = "0.8.0"
 hex = "0.3.1"

--- a/lib/vm/src/backends/cranelift.rs
+++ b/lib/vm/src/backends/cranelift.rs
@@ -2,7 +2,7 @@
 use wasmer_clif_backend::CraneliftCompiler;
 use wasmer_runtime::{compile_with, Backend, Instance, Module};
 
-static FAKE_GAS_AVAILBLE: u64 = 1_000_000;
+static FAKE_GAS_AVAILABLE: u64 = 1_000_000;
 
 pub fn compile(code: &[u8]) -> Module {
     compile_with(code, &CraneliftCompiler::new()).unwrap()

--- a/lib/vm/src/backends/cranelift.rs
+++ b/lib/vm/src/backends/cranelift.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "cranelift")]
 use wasmer_clif_backend::CraneliftCompiler;
-use wasmer_runtime::{compile_with, Backend, Module};
+use wasmer_runtime::{compile_with, Backend, Instance, Module};
+
+static FAKE_GAS_AVAILBLE: u64 = 1_000_000;
 
 pub fn compile(code: &[u8]) -> Module {
     compile_with(code, &CraneliftCompiler::new()).unwrap()
@@ -8,4 +10,10 @@ pub fn compile(code: &[u8]) -> Module {
 
 pub fn backend() -> Backend {
     Backend::Cranelift
+}
+
+pub fn set_gas(_instance: &mut Instance, _limit: u64) {}
+
+pub fn get_gas(_instance: &Instance) -> u64 {
+    FAKE_GAS_AVAILABLE
 }

--- a/lib/vm/src/backends/cranelift.rs
+++ b/lib/vm/src/backends/cranelift.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "cranelift")]
 use wasmer_clif_backend::CraneliftCompiler;
 use wasmer_runtime::{compile_with, Backend, Module};
 

--- a/lib/vm/src/backends/mod.rs
+++ b/lib/vm/src/backends/mod.rs
@@ -2,7 +2,7 @@ pub mod cranelift;
 pub mod singlepass;
 
 #[cfg(feature = "default-cranelift")]
-pub use cranelift::{backend, compile};
+pub use cranelift::{backend, compile, get_gas, set_gas};
 
 #[cfg(feature = "default-singlepass")]
-pub use singlepass::{backend, compile};
+pub use singlepass::{backend, compile, get_gas, set_gas};

--- a/lib/vm/src/backends/mod.rs
+++ b/lib/vm/src/backends/mod.rs
@@ -1,3 +1,8 @@
-mod cranelift;
+pub mod cranelift;
+pub mod singlepass;
 
+#[cfg(feature = "default-cranelift")]
 pub use cranelift::{backend, compile};
+
+#[cfg(feature = "default-singlepass")]
+pub use singlepass::{backend, compile};

--- a/lib/vm/src/backends/singlepass.rs
+++ b/lib/vm/src/backends/singlepass.rs
@@ -1,0 +1,11 @@
+#![cfg(feature = "singlepass")]
+use wasmer_singlepass_backend::SinglePassCompiler;
+use wasmer_runtime::{compile_with, Backend, Module};
+
+pub fn compile(code: &[u8]) -> Module {
+    compile_with(code, &SinglePassCompiler::new()).unwrap()
+}
+
+pub fn backend() -> Backend {
+    Backend::Singlepass
+}

--- a/lib/vm/src/backends/singlepass.rs
+++ b/lib/vm/src/backends/singlepass.rs
@@ -1,9 +1,18 @@
 #![cfg(feature = "singlepass")]
-use wasmer_singlepass_backend::SinglePassCompiler;
+use wasmer_middleware_common::metering;
 use wasmer_runtime::{compile_with, Backend, Module};
+use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
+use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
+
+static GAS_LIMIT: u64 = 10_000_000_000;
 
 pub fn compile(code: &[u8]) -> Module {
-    compile_with(code, &SinglePassCompiler::new()).unwrap()
+    let c: StreamingCompiler<SinglePassMCG, _, _, _, _> = StreamingCompiler::new(move || {
+        let mut chain = MiddlewareChain::new();
+        chain.push(metering::Metering::new(GAS_LIMIT));
+        chain
+    });
+    compile_with(code, &c).unwrap()
 }
 
 pub fn backend() -> Backend {

--- a/lib/vm/src/backends/singlepass.rs
+++ b/lib/vm/src/backends/singlepass.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "singlepass")]
 use wasmer_middleware_common::metering;
-use wasmer_runtime::{compile_with, Backend, Module};
+use wasmer_runtime::{compile_with, Backend, Instance, Module};
 use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
 use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
 
@@ -17,4 +17,14 @@ pub fn compile(code: &[u8]) -> Module {
 
 pub fn backend() -> Backend {
     Backend::Singlepass
+}
+
+pub fn set_gas(instance: &mut Instance, limit: u64) {
+    let used = GAS_LIMIT - limit;
+    metering::set_points_used(instance, used)
+}
+
+pub fn get_gas(instance: &Instance) -> u64 {
+    let used = metering::get_points_used(instance);
+    GAS_LIMIT - used
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -91,8 +91,8 @@ pub struct Response {
 pub fn mock_params(signer: &str, sent: &[Coin], balance: &[Coin]) -> Params {
     Params {
         block: BlockInfo {
-            height: 12345,
-            time: 1571797419,
+            height: 12_345,
+            time: 1_571_797_419,
             chain_id: "cosmos-testnet-14002".to_string(),
         },
         message: MessageInfo {


### PR DESCRIPTION
Closes #18 
Closes #28 

- [x] Add features to lib/vm to choose singlepass or cranelift
- [x] Update CI to handle both variants (and use nightly rust for singlepass)
- [x] Use metering compiler for singlepass
- [x] Expose gas metering functions in backend - set_gas and get_gas
- [x] Update lib/vm api to use the gas metering and return gas used