### PR TITLE
Simplify integration tests

### DIFF
--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -1,11 +1,9 @@
-use cosmwasm::mock::MockStorage;
 use cosmwasm::serde::{from_slice, to_vec};
 use cosmwasm::storage::Storage;
 use cosmwasm::types::{coin, mock_params, CosmosMsg};
-use cosmwasm_vm::{call_handle, call_init, Instance};
 use cosmwasm_vm::testing::{handle, init, mock_instance};
 
-use hackatom::contract::{HandleMsg, InitMsg, State, CONFIG_KEY};
+use hackatom::contract::{InitMsg, State, CONFIG_KEY};
 
 /**
 This integration test tries to run and call the generated wasm.
@@ -29,14 +27,16 @@ fn proper_initialization() {
     let res = init(&mut store, params, msg).unwrap();
     assert_eq!(0, res.messages.len());
 
-//    // it worked, let's check the state
-//    let data = store.get(CONFIG_KEY).expect("no data stored");
-//    let state: State = from_slice(&data).unwrap();
-//    assert_eq!(state, State{
-//        verifier: "verifies".to_string(),
-//        beneficiary: "benefits".to_string(),
-//        funder: "creator".to_string(),
-//    });
+    // it worked, let's check the state
+    store.with_storage(|store| {
+        let data = store.get(CONFIG_KEY).expect("no data stored");
+        let state: State = from_slice(&data).unwrap();
+        assert_eq!(state, State {
+            verifier: "verifies".to_string(),
+            beneficiary: "benefits".to_string(),
+            funder: "creator".to_string(),
+        });
+    });
 }
 
 #[test]
@@ -48,48 +48,36 @@ fn fails_on_bad_init() {
     assert_eq!(true, res.is_err());
 }
 
-
-// Note this is very similar in scope and size to proper_handle in contracts.rs tests
-// Making it as easy to write vm external integration tests as rust unit tests
 #[test]
-fn successful_init_and_handle() {
-    assert!(WASM.len() > 100000);
-    let storage = MockStorage::new();
-    let mut instance = Instance::from_code(&WASM, storage).unwrap();
+fn proper_handle() {
+    let mut store = mock_instance(WASM);
 
-    // prepare arguments
-    let params = mock_params("creator", &coin("1000", "earth"), &[]);
-    let msg = to_vec(&InitMsg {
+    // initialize the store
+    let init_msg = to_vec(&InitMsg {
         verifier: String::from("verifies"),
         beneficiary: String::from("benefits"),
     })
-    .unwrap();
+        .unwrap();
+    let init_params = mock_params("creator", &coin("1000", "earth"), &coin("1000", "earth"));
+    let init_res = init(&mut store, init_params, init_msg).unwrap();
+    assert_eq!(0, init_res.messages.len());
 
-    // call and check
-    let res = call_init(&mut instance, &params, &msg).unwrap();
-    let msgs = res.unwrap().messages;
-    assert_eq!(msgs.len(), 0);
-
-    // now try to handle this one
-    let params = mock_params("verifies", &coin("15", "earth"), &coin("1015", "earth"));
-    let msg = to_vec(&HandleMsg {}).unwrap();
-    let res = call_handle(&mut instance, &params, &msg).unwrap();
-    let msgs = res.unwrap().messages;
-    assert_eq!(1, msgs.len());
-    let msg = msgs.get(0).expect("no message");
+    // beneficiary can release it
+    let handle_params = mock_params("verifies", &coin("15", "earth"), &coin("1015", "earth"));
+    let handle_res = handle(&mut store, handle_params, Vec::new()).unwrap();
+    assert_eq!(1, handle_res.messages.len());
+    let msg = handle_res.messages.get(0).expect("no message");
     assert_eq!(msg, &CosmosMsg::Send{
         from_address: "cosmos2contract".to_string(),
         to_address: "benefits".to_string(),
         amount: coin("1015", "earth"),
     });
 
-    // we can check the storage as well
-    instance.with_storage(|store| {
-        let foo = store.get(b"foo");
-        assert!(foo.is_none());
+    // it worked, let's check the state
+    store.with_storage(|store| {
         let data = store.get(CONFIG_KEY).expect("no data stored");
         let state: State = from_slice(&data).unwrap();
-        assert_eq!(state, State{
+        assert_eq!(state, State {
             verifier: "verifies".to_string(),
             beneficiary: "benefits".to_string(),
             funder: "creator".to_string(),
@@ -99,29 +87,31 @@ fn successful_init_and_handle() {
 
 #[test]
 fn failed_handle() {
-    let storage = MockStorage::new();
-    let mut instance = Instance::from_code(&WASM, storage).unwrap();
+    let mut store = mock_instance(WASM);
 
     // initialize the store
     let init_msg = to_vec(&InitMsg {
         verifier: String::from("verifies"),
         beneficiary: String::from("benefits"),
     })
-    .unwrap();
+        .unwrap();
     let init_params = mock_params("creator", &coin("1000", "earth"), &coin("1000", "earth"));
-    let init_res = call_init(&mut instance, &init_params, &init_msg).unwrap();
-    let init_msgs = init_res.unwrap().messages;
-    assert_eq!(0, init_msgs.len());
+    let init_res = init(&mut store, init_params, init_msg).unwrap();
+    assert_eq!(0, init_res.messages.len());
 
     // beneficiary can release it
     let handle_params = mock_params("benefits", &[], &coin("1000", "earth"));
-    let handle_res = call_handle(&mut instance, &handle_params, b"").unwrap();
+    let handle_res = handle(&mut store, handle_params, Vec::new());
     assert!(handle_res.is_err());
 
-    // state should be saved
-    instance.with_storage(|store| {
+    // state should not change
+    store.with_storage(|store| {
         let data = store.get(CONFIG_KEY).expect("no data stored");
         let state: State = from_slice(&data).unwrap();
-        assert_eq!(state.verifier, String::from("verifies"));
+        assert_eq!(state, State {
+            verifier: "verifies".to_string(),
+            beneficiary: "benefits".to_string(),
+            funder: "creator".to_string(),
+        });
     });
 }

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -6,6 +6,7 @@ pub mod errors;
 mod instance;
 mod memory;
 mod modules;
+pub mod testing;
 mod wasm_store;
 
 pub use crate::cache::CosmCache;

--- a/lib/vm/src/testing.rs
+++ b/lib/vm/src/testing.rs
@@ -1,0 +1,32 @@
+// This file has some helpers for integration tests.
+// They should be imported via full path to ensure there is no confusion
+// use cosmwasm_vm::testing::X
+
+use std::vec::Vec;
+
+use cosmwasm::mock::MockStorage;
+use cosmwasm::storage::Storage;
+use cosmwasm::types::{ContractResult, Params};
+
+use crate::calls::{call_handle, call_init};
+use crate::instance::Instance;
+
+pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage> {
+    let storage = MockStorage::new();
+    Instance::from_code(wasm, storage).unwrap()
+}
+
+// init mimicks the call signature of the smart contracts.
+// thus it moves params and msg rather than take them as reference.
+// this is inefficient here, but only used in test code
+pub fn init<T: Storage + 'static>(instance: &mut Instance<T>, params: Params, msg: Vec<u8>) -> ContractResult {
+    call_init(instance, &params, &msg).unwrap()
+}
+
+// handle mimicks the call signature of the smart contracts.
+// thus it moves params and msg rather than take them as reference.
+// this is inefficient here, but only used in test code
+pub fn handle<T: Storage + 'static>(instance: &mut Instance<T>, params: Params, msg: Vec<u8>) -> ContractResult {
+    call_handle(instance, &params, &msg).unwrap()
+}
+


### PR DESCRIPTION
Closes #58 

Add some helpers in `cosmwasm_vm::testing` to make porting unit tests to integration tests super-simple.

Currently, this just involves adding an import to the file:

```rust
use cosmwasm_vm::testing::{handle, init, mock_instance};
```

and then changing one line on the top of each test case:

```rust
// unit tests
let mut store = MockStorage::new();
// integration tests
let mut store = mock_instance(WASM);
```

Note that you cannot access the `store` directly any more to query, but with #66 we can use the `query` interface for both unit tests and integration tests to access the store. Until then if you need to access the internal db stroage, you can simply embed the queries to the database inside a block, like:

```rust
    store.with_storage(|store| {
        let data = store.get(CONFIG_KEY).expect("no data stored");
        let state: State = from_slice(&data).unwrap();
        assert_eq!(state.verifier, String::from("verifies"));
    });

```