### PR TITLE
Allow mock_params to take multiple types of arguments

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -5,7 +5,7 @@ use snafu::ResultExt;
 
 use crate::errors::{ContractErr, Result, Utf8Err};
 use crate::traits::{Api, Extern, ReadonlyStorage, Storage};
-use crate::types::{BlockInfo, Coin, ContractInfo, MessageInfo, Params, CanonicalAddr, HumanAddr};
+use crate::types::{BlockInfo, CanonicalAddr, Coin, ContractInfo, HumanAddr, MessageInfo, Params};
 
 // dependencies are all external requirements that can be injected for unit tests
 pub fn dependencies(canonical_length: usize) -> Extern<MockStorage, MockApi> {
@@ -84,7 +84,12 @@ impl Api for MockApi {
 
     fn human_address(&self, canonical: &CanonicalAddr) -> Result<HumanAddr> {
         // remove trailing 0's (TODO: fix this - but fine for first tests)
-        let trimmed: Vec<u8> = canonical.as_bytes().iter().cloned().filter(|&x| x != 0).collect();
+        let trimmed: Vec<u8> = canonical
+            .as_bytes()
+            .iter()
+            .cloned()
+            .filter(|&x| x != 0)
+            .collect();
         // convert to utf8
         let human = from_utf8(&trimmed).context(Utf8Err {})?;
         Ok(HumanAddr(human.to_string()))
@@ -93,12 +98,13 @@ impl Api for MockApi {
 
 // just set signer, sent funds, and balance - rest given defaults
 // this is intended for use in testcode only
-pub fn mock_params<T: Api>(
-    precompiles: &T,
-    signer: &str,
+pub fn mock_params<T: Api, U: Into<HumanAddr>>(
+    api: &T,
+    signer: U,
     sent: &[Coin],
     balance: &[Coin],
 ) -> Params {
+    let signer = signer.into();
     Params {
         block: BlockInfo {
             height: 12_345,
@@ -106,7 +112,7 @@ pub fn mock_params<T: Api>(
             chain_id: "cosmos-testnet-14002".to_string(),
         },
         message: MessageInfo {
-            signer: precompiles.canonical_address(&HumanAddr(signer.to_string())).unwrap(),
+            signer: api.canonical_address(&signer).unwrap(),
             sent_funds: if sent.is_empty() {
                 None
             } else {
@@ -114,7 +120,9 @@ pub fn mock_params<T: Api>(
             },
         },
         contract: ContractInfo {
-            address: precompiles.canonical_address(&HumanAddr("cosmos2contract".to_string())).unwrap(),
+            address: api
+                .canonical_address(&HumanAddr("cosmos2contract".to_string()))
+                .unwrap(),
             balance: if balance.is_empty() {
                 None
             } else {
@@ -128,6 +136,23 @@ pub fn mock_params<T: Api>(
 mod test {
     use super::*;
 
+    use crate::types::coin;
+
+    #[test]
+    fn mock_params_arguments() {
+        let name = HumanAddr("my name".to_string());
+        let api = MockApi::new(20);
+
+        // make sure we can generate with &str, &HumanAddr, and HumanAddr
+        let a = mock_params(&api, "my name", &[], &coin("100", "atom"));
+        let b = mock_params(&api, &name, &[], &coin("100", "atom"));
+        let c = mock_params(&api, name, &[], &coin("100", "atom"));
+
+        // and the results are the same
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+
     #[test]
     fn get_and_set() {
         let mut store = MockStorage::new();
@@ -139,22 +164,22 @@ mod test {
 
     #[test]
     fn flip_addresses() {
-        let precompiles = MockApi::new(20);
+        let api = MockApi::new(20);
         let human = HumanAddr("shorty".to_string());
-        let canon = precompiles.canonical_address(&human).unwrap();
+        let canon = api.canonical_address(&human).unwrap();
         assert_eq!(canon.len(), 20);
         assert_eq!(&canon.as_bytes()[0..6], human.as_str().as_bytes());
         assert_eq!(&canon.as_bytes()[6..], &[0u8; 14]);
 
-        let recovered = precompiles.human_address(&canon).unwrap();
+        let recovered = api.human_address(&canon).unwrap();
         assert_eq!(human, recovered);
     }
 
     #[test]
     #[should_panic]
     fn canonical_length_enforced() {
-        let precompiles = MockApi::new(10);
+        let api = MockApi::new(10);
         let human = HumanAddr("longer-than-10".to_string());
-        let _ = precompiles.canonical_address(&human).unwrap();
+        let _ = api.canonical_address(&human).unwrap();
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,9 @@ impl HumanAddr {
     pub fn as_str(&self) -> &str {
         &self.0
     }
-    pub fn len(&self) -> usize { self.0.len() }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 impl fmt::Display for HumanAddr {
@@ -22,11 +24,25 @@ impl fmt::Display for HumanAddr {
     }
 }
 
+impl From<&str> for HumanAddr {
+    fn from(addr: &str) -> Self {
+        HumanAddr(addr.to_string())
+    }
+}
+
+impl From<&HumanAddr> for HumanAddr {
+    fn from(addr: &HumanAddr) -> Self {
+        HumanAddr(addr.0.to_string())
+    }
+}
+
 impl CanonicalAddr {
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
-    pub fn len(&self) -> usize { self.0.len() }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 // upper-case hex


### PR DESCRIPTION
Closes #91 

Now accepts `&str`, `&HumanAddr` and `HumanAddr`