### PR TITLE
Add fmt and clippy tests to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
       - cranelift_vm
       - hackatom
       - fmt
+      - clippy
 
 jobs:
   base:
@@ -145,7 +146,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - v4-cargo-cache-base-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - v4-cargo-cache-fmt-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Cargo format
           command: cargo fmt
@@ -167,4 +168,29 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: v4-cargo-cache-base-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: v4-cargo-cache-fmt-{{ arch }}-{{ checksum "Cargo.lock" }}
+
+  clippy:
+    docker:
+      - image: rust:1.39
+    steps:
+      - checkout
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - restore_cache:
+          keys:
+            - v4-cargo-cache-clippy-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Clippy linting
+          command: cargo clippy -- -D warnings
+      - run:
+          name: Clippy linting on hackatom
+          command: cd contracts/hackatom && cargo clippy -- -D warnings
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: v4-cargo-cache-clippy-{{ arch }}-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,8 +161,8 @@ jobs:
           command: |
             CHANGES_IN_REPO=$(git status --porcelain)
             if [[ -n "$CHANGES_IN_REPO" ]]; then
-              echo "Repository is dirty. Showing 'git status' and 'git diff' for debugging now:"
-              git status && git diff
+              echo "Repository is dirty. Showing 'git status' for debugging now:"
+              git status
               exit 1
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
       - singlepass_vm
       - cranelift_vm
       - hackatom
+      - fmt
 
 jobs:
   base:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,9 @@ jobs:
           keys:
             - v4-cargo-cache-fmt-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
+          name: Add rustfmt component
+          command: rustup component add rustfmt            -
+      - run:
           name: Cargo format
           command: cargo fmt
       - run:
@@ -181,6 +184,9 @@ jobs:
       - restore_cache:
           keys:
             - v4-cargo-cache-clippy-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Add clippy component
+          command: rustup component add clippy            -
       - run:
           name: Clippy linting
           command: cargo clippy -- -D warnings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,3 +133,37 @@ jobs:
             - target/wasm32-unknown-unknown/release/build
             - target/wasm32-unknown-unknown/release/deps
           key: v4-cargo-cache-hackatom-{{ arch }}-{{ checksum "Cargo.lock" }}
+
+  fmt:
+    docker:
+      - image: rust:1.39
+    steps:
+      - checkout
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - restore_cache:
+          keys:
+            - v4-cargo-cache-base-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Cargo format
+          command: cargo fmt
+      - run:
+          name: Cargo format hackatom
+          command: cd contracts/hackatom && cargo fmt
+      - run:
+          name: Ensure checked-in source code is properly formatted
+          command: |
+            CHANGES_IN_REPO=$(git status --porcelain)
+            if [[ -n "$CHANGES_IN_REPO" ]]; then
+              echo "Repository is dirty. Showing 'git status' and 'git diff' for debugging now:"
+              git status && git diff
+              exit 1
+            fi
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: v4-cargo-cache-base-{{ arch }}-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
           command: cargo clippy -- -D warnings
       - run:
           name: Clippy linting on lib/vm (use flags for stable support)
-          command: cargo clippy --no-default-features --features default-cranelift
+          command: cd lib/vm && cargo clippy --no-default-features --features default-cranelift
       - run:
           name: Clippy linting on hackatom
           command: cd contracts/hackatom && cargo clippy -- -D warnings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,9 @@ jobs:
           name: Clippy linting
           command: cargo clippy -- -D warnings
       - run:
+          name: Clippy linting on lib/vm (use flags for stable support)
+          command: cargo clippy --no-default-features --features default-cranelift
+      - run:
           name: Clippy linting on hackatom
           command: cd contracts/hackatom && cargo clippy -- -D warnings
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
 jobs:
   base:
     docker:
-      - image: rust:1.37
+      - image: rust:1.39
     steps:
       - checkout
       - run:
@@ -69,7 +69,7 @@ jobs:
 
   cranelift_vm:
     docker:
-      - image: rust:1.37
+      - image: rust:1.39
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
             - v4-cargo-cache-fmt-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
-          command: rustup component add rustfmt            -
+          command: rustup component add rustfmt
       - run:
           name: Cargo format
           command: cargo fmt
@@ -186,7 +186,7 @@ jobs:
             - v4-cargo-cache-clippy-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Add clippy component
-          command: rustup component add clippy            -
+          command: rustup component add clippy
       - run:
           name: Clippy linting
           command: cargo clippy -- -D warnings

--- a/lib/vm/src/middleware/deterministic.rs
+++ b/lib/vm/src/middleware/deterministic.rs
@@ -16,6 +16,8 @@ use wasmer_runtime_core::{
 pub struct DeterministicMiddleware;
 
 impl DeterministicMiddleware {
+    // this is only use in singlepass, not cranelift, so don't trigger ci linting errors
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {}
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -73,7 +73,7 @@ pub fn transactional_deps<S: Storage, A: Api, T>(
     let c = StorageTransaction::new(&mut deps.storage);
     let mut deps = Extern {
         storage: c,
-        api: deps.api.clone(),
+        api: deps.api,
     };
     let res = tx(&mut deps);
     if res.is_ok() {
@@ -127,7 +127,6 @@ mod test {
 
         assert_eq!(base.get(b"subtx"), None);
     }
-
 
     #[test]
     fn transactional_works() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,9 @@ impl HumanAddr {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl fmt::Display for HumanAddr {
@@ -42,6 +45,9 @@ impl CanonicalAddr {
     }
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 


### PR DESCRIPTION
Let's ensure all code is clean before merged.
We don't want to mix up warnings on aesthetics with warnings on failing tests, so we use a different ci job for this. It should display separately in the warnings.