### PR TITLE
Typed msg in args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -216,7 +216,7 @@ mod tests {
             &coin("15", "earth"),
             &coin("1015", "earth"),
         );
-        let handle_res = handle(&mut deps, handle_params, HandleMsg{}).unwrap();
+        let handle_res = handle(&mut deps, handle_params, HandleMsg {}).unwrap();
         assert_eq!(1, handle_res.messages.len());
         let msg = handle_res.messages.get(0).expect("no message");
         assert_eq!(
@@ -258,7 +258,7 @@ mod tests {
         // beneficiary can release it
         let handle_params =
             mock_params(&deps.api, beneficiary.as_str(), &[], &coin("1000", "earth"));
-        let handle_res = handle(&mut deps, handle_params, HandleMsg{});
+        let handle_res = handle(&mut deps, handle_params, HandleMsg {});
         assert!(handle_res.is_err());
 
         // state should not change

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -36,9 +36,8 @@ pub static CONFIG_KEY: &[u8] = b"config";
 pub fn init<S: Storage, A: Api>(
     deps: &mut Extern<S, A>,
     params: Params,
-    msg: Vec<u8>,
+    msg: InitMsg,
 ) -> Result<Response> {
-    let msg: InitMsg = from_slice(&msg).context(ParseErr { kind: "InitMsg" })?;
     deps.storage.set(
         CONFIG_KEY,
         &to_vec(&State {
@@ -54,7 +53,7 @@ pub fn init<S: Storage, A: Api>(
 pub fn handle<S: Storage, A: Api>(
     deps: &mut Extern<S, A>,
     params: Params,
-    _: Vec<u8>,
+    _: HandleMsg,
 ) -> Result<Response> {
     let data = deps.storage.get(CONFIG_KEY).context(ContractErr {
         msg: "uninitialized data",
@@ -79,8 +78,7 @@ pub fn handle<S: Storage, A: Api>(
     }
 }
 
-pub fn query<S: Storage, A: Api>(deps: &Extern<S, A>, msg: Vec<u8>) -> Result<Vec<u8>> {
-    let msg: QueryMsg = from_slice(&msg).context(ParseErr { kind: "QueryMsg" })?;
+pub fn query<S: Storage, A: Api>(deps: &Extern<S, A>, msg: QueryMsg) -> Result<Vec<u8>> {
     match msg {
         QueryMsg::Verifier {} => query_verifier(deps),
     }
@@ -104,7 +102,6 @@ mod tests {
     use std::str::from_utf8;
 
     use super::*;
-    use cosmwasm::errors::Error;
     use cosmwasm::mock::{dependencies, mock_params};
     use cosmwasm::storage::transactional_deps;
     // import trait to get access to read
@@ -124,11 +121,10 @@ mod tests {
             funder: deps.api.canonical_address(&creator).unwrap(),
         };
 
-        let msg = to_vec(&InitMsg {
+        let msg = InitMsg {
             verifier,
             beneficiary,
-        })
-        .unwrap();
+        };
         let params = mock_params(&deps.api, creator.as_str(), &coin("1000", "earth"), &[]);
         let res = init(&mut deps, params, msg).unwrap();
         assert_eq!(0, res.messages.len());
@@ -146,28 +142,18 @@ mod tests {
         let verifier = HumanAddr(String::from("verifies"));
         let beneficiary = HumanAddr(String::from("benefits"));
         let creator = HumanAddr(String::from("creator"));
-        let msg = to_vec(&InitMsg {
+        let msg = InitMsg {
             verifier: verifier.clone(),
             beneficiary,
-        })
-        .unwrap();
+        };
         let params = mock_params(&deps.api, creator.as_str(), &coin("1000", "earth"), &[]);
         let res = init(&mut deps, params, msg).unwrap();
         assert_eq!(0, res.messages.len());
 
         // now let's query
-        let qmsg = to_vec(&QueryMsg::Verifier {}).unwrap();
-        let qres = query(&deps, qmsg).unwrap();
+        let qres = query(&deps, QueryMsg::Verifier {}).unwrap();
         let returned = from_utf8(&qres).unwrap();
         assert_eq!(verifier.as_str(), returned);
-
-        // bad query returns parse error
-        let qres = query(&deps, b"no json here".to_vec());
-        match qres {
-            Ok(_) => panic!("Call should fail"),
-            Err(Error::ParseErr { kind, .. }) => assert_eq!(kind, "QueryMsg"),
-            Err(e) => panic!("Unexpected error: {}", e),
-        }
     }
 
     #[test]
@@ -185,11 +171,10 @@ mod tests {
 
         // let's see if we can checkpoint on a contract
         let res = transactional_deps(&mut deps, &|deps| {
-            let msg = to_vec(&InitMsg {
+            let msg = InitMsg {
                 verifier: verifier.clone(),
                 beneficiary: beneficiary.clone(),
-            })
-            .unwrap();
+            };
             let params = mock_params(&deps.api, creator.as_str(), &coin("1000", "earth"), &[]);
 
             init(deps, params, msg)
@@ -204,15 +189,6 @@ mod tests {
     }
 
     #[test]
-    fn fails_on_bad_init() {
-        let mut deps = dependencies(20);
-        let bad_msg = b"{}".to_vec();
-        let params = mock_params(&deps.api, "creator", &coin("1000", "earth"), &[]);
-        let res = init(&mut deps, params, bad_msg);
-        assert_eq!(true, res.is_err());
-    }
-
-    #[test]
     fn proper_handle() {
         let mut deps = dependencies(20);
 
@@ -220,11 +196,10 @@ mod tests {
         let verifier = HumanAddr(String::from("verifies"));
         let beneficiary = HumanAddr(String::from("benefits"));
 
-        let init_msg = to_vec(&InitMsg {
+        let init_msg = InitMsg {
             verifier: verifier.clone(),
             beneficiary: beneficiary.clone(),
-        })
-        .unwrap();
+        };
         let init_params = mock_params(
             &deps.api,
             "creator",
@@ -241,7 +216,7 @@ mod tests {
             &coin("15", "earth"),
             &coin("1015", "earth"),
         );
-        let handle_res = handle(&mut deps, handle_params, Vec::new()).unwrap();
+        let handle_res = handle(&mut deps, handle_params, HandleMsg{}).unwrap();
         assert_eq!(1, handle_res.messages.len());
         let msg = handle_res.messages.get(0).expect("no message");
         assert_eq!(
@@ -267,11 +242,10 @@ mod tests {
         let beneficiary = HumanAddr(String::from("benefits"));
         let creator = HumanAddr(String::from("creator"));
 
-        let init_msg = to_vec(&InitMsg {
+        let init_msg = InitMsg {
             verifier: verifier.clone(),
             beneficiary: beneficiary.clone(),
-        })
-        .unwrap();
+        };
         let init_params = mock_params(
             &deps.api,
             creator.as_str(),
@@ -284,7 +258,7 @@ mod tests {
         // beneficiary can release it
         let handle_params =
             mock_params(&deps.api, beneficiary.as_str(), &[], &coin("1000", "earth"));
-        let handle_res = handle(&mut deps, handle_params, Vec::new());
+        let handle_res = handle(&mut deps, handle_params, HandleMsg{});
         assert!(handle_res.is_err());
 
         // state should not change

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -132,7 +132,7 @@ fn proper_handle() {
         &coin("15", "earth"),
         &coin("1015", "earth"),
     );
-    let handle_res = handle(&mut deps, handle_params, Vec::new()).unwrap();
+    let handle_res = handle(&mut deps, handle_params, b"{}".to_vec()).unwrap();
     assert_eq!(1, handle_res.messages.len());
     let msg = handle_res.messages.get(0).expect("no message");
     assert_eq!(
@@ -174,7 +174,7 @@ fn failed_handle() {
 
     // beneficiary can release it
     let handle_params = mock_params(&deps.api, beneficiary.as_str(), &[], &coin("1000", "earth"));
-    let handle_res = handle(&mut deps, handle_params, Vec::new());
+    let handle_res = handle(&mut deps, handle_params, b"{}".to_vec());
     assert!(handle_res.is_err());
 
     // state should not change

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -1,13 +1,13 @@
 use std::str::from_utf8;
 
 use cosmwasm::mock::mock_params;
-use cosmwasm::serde::{from_slice, to_vec};
+use cosmwasm::serde::from_slice;
 use cosmwasm::traits::{Api, ReadonlyStorage};
 use cosmwasm::types::{coin, CosmosMsg, HumanAddr, QueryResult};
 
 use cosmwasm_vm::testing::{handle, init, mock_instance, query};
 
-use hackatom::contract::{InitMsg, QueryMsg, State, CONFIG_KEY};
+use hackatom::contract::{HandleMsg, InitMsg, QueryMsg, State, CONFIG_KEY};
 
 /**
 This integration test tries to run and call the generated wasm.
@@ -47,11 +47,10 @@ fn proper_initialization() {
         funder: deps.api.canonical_address(&creator).unwrap(),
     };
 
-    let msg = to_vec(&InitMsg {
+    let msg = InitMsg {
         verifier,
         beneficiary,
-    })
-    .unwrap();
+    };
     let params = mock_params(&deps.api, "creator", &coin("1000", "earth"), &[]);
     let res = init(&mut deps, params, msg).unwrap();
     assert_eq!(0, res.messages.len());
@@ -71,23 +70,21 @@ fn init_and_query() {
     let verifier = HumanAddr(String::from("verifies"));
     let beneficiary = HumanAddr(String::from("benefits"));
     let creator = HumanAddr(String::from("creator"));
-    let msg = to_vec(&InitMsg {
+    let msg = InitMsg {
         verifier: verifier.clone(),
         beneficiary,
-    })
-    .unwrap();
+    };
     let params = mock_params(&deps.api, creator.as_str(), &coin("1000", "earth"), &[]);
     let res = init(&mut deps, params, msg).unwrap();
     assert_eq!(0, res.messages.len());
 
     // now let's query
-    let qmsg = to_vec(&QueryMsg::Verifier {}).unwrap();
-    let qres = query(&mut deps, qmsg).unwrap();
+    let qres = query(&mut deps, QueryMsg::Verifier {}).unwrap();
     let returned = from_utf8(&qres).unwrap();
     assert_eq!(verifier.as_str(), returned);
 
-    // bad query returns parse error
-    let qres = query(&mut deps, b"no json here".to_vec());
+    // bad query returns parse error (pass wrong type - this connection is not enforced)
+    let qres = query(&mut deps, HandleMsg {});
     match qres {
         QueryResult::Err(msg) => assert!(msg.starts_with("Error parsing QueryMsg:"), msg),
         _ => panic!("Call should fail"),
@@ -97,9 +94,9 @@ fn init_and_query() {
 #[test]
 fn fails_on_bad_init() {
     let mut deps = mock_instance(WASM);
-    let bad_msg = b"{}".to_vec();
     let params = mock_params(&deps.api, "creator", &coin("1000", "earth"), &[]);
-    let res = init(&mut deps, params, bad_msg);
+    // bad init returns parse error (pass wrong type - this connection is not enforced)
+    let res = init(&mut deps, params, HandleMsg {});
     assert_eq!(true, res.is_err());
 }
 
@@ -111,11 +108,10 @@ fn proper_handle() {
     let verifier = HumanAddr(String::from("verifies"));
     let beneficiary = HumanAddr(String::from("benefits"));
 
-    let init_msg = to_vec(&InitMsg {
+    let init_msg = InitMsg {
         verifier: verifier.clone(),
         beneficiary: beneficiary.clone(),
-    })
-    .unwrap();
+    };
     let init_params = mock_params(
         &deps.api,
         "creator",
@@ -132,7 +128,7 @@ fn proper_handle() {
         &coin("15", "earth"),
         &coin("1015", "earth"),
     );
-    let handle_res = handle(&mut deps, handle_params, b"{}".to_vec()).unwrap();
+    let handle_res = handle(&mut deps, handle_params, HandleMsg {}).unwrap();
     assert_eq!(1, handle_res.messages.len());
     let msg = handle_res.messages.get(0).expect("no message");
     assert_eq!(
@@ -158,11 +154,10 @@ fn failed_handle() {
     let beneficiary = HumanAddr(String::from("benefits"));
     let creator = HumanAddr(String::from("creator"));
 
-    let init_msg = to_vec(&InitMsg {
+    let init_msg = InitMsg {
         verifier: verifier.clone(),
         beneficiary: beneficiary.clone(),
-    })
-    .unwrap();
+    };
     let init_params = mock_params(
         &deps.api,
         creator.as_str(),
@@ -174,7 +169,7 @@ fn failed_handle() {
 
     // beneficiary can release it
     let handle_params = mock_params(&deps.api, beneficiary.as_str(), &[], &coin("1000", "earth"));
-    let handle_res = handle(&mut deps, handle_params, b"{}".to_vec());
+    let handle_res = handle(&mut deps, handle_params, HandleMsg {});
     assert!(handle_res.is_err());
 
     // state should not change

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -41,6 +41,7 @@ wasmer-runtime-core = "0.11.0"
 wasmer-middleware-common = "0.11.0"
 wasmer-clif-backend = {version = "0.11.0", optional = true }
 wasmer-singlepass-backend = {version = "0.11.0", optional = true }
+serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
 sha2 = "0.8.0"
 hex = "0.3.1"

--- a/lib/vm/src/testing.rs
+++ b/lib/vm/src/testing.rs
@@ -1,9 +1,6 @@
 // This file has some helpers for integration tests.
 // They should be imported via full path to ensure there is no confusion
 // use cosmwasm_vm::testing::X
-
-use std::vec::Vec;
-
 use serde::Serialize;
 
 use cosmwasm::mock::{dependencies, MockApi, MockStorage};
@@ -54,7 +51,7 @@ pub fn handle<S: Storage + 'static, A: Api + 'static, T: Serialize>(
 // this is inefficient here, but only used in test code
 pub fn query<S: Storage + 'static, A: Api + 'static, T: Serialize>(
     instance: &mut Instance<S, A>,
-    msg: Vec<u8>,
+    msg: T,
 ) -> QueryResult {
     let msg = to_vec(&msg);
     if let Err(e) = msg {

--- a/lib/vm/src/testing.rs
+++ b/lib/vm/src/testing.rs
@@ -4,7 +4,10 @@
 
 use std::vec::Vec;
 
+use serde::Serialize;
+
 use cosmwasm::mock::{dependencies, MockApi, MockStorage};
+use cosmwasm::serde::to_vec;
 use cosmwasm::traits::{Api, Storage};
 use cosmwasm::types::{ContractResult, Params, QueryResult};
 
@@ -19,31 +22,43 @@ pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi> {
 // init mimicks the call signature of the smart contracts.
 // thus it moves params and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn init<S: Storage + 'static, A: Api + 'static>(
+pub fn init<S: Storage + 'static, A: Api + 'static, T: Serialize>(
     instance: &mut Instance<S, A>,
     params: Params,
-    msg: Vec<u8>,
+    msg: T,
 ) -> ContractResult {
-    call_init(instance, &params, &msg).unwrap()
+    let msg = to_vec(&msg);
+    if let Err(e) = msg {
+        return ContractResult::Err(e.to_string());
+    }
+    call_init(instance, &params, &msg.unwrap()).unwrap()
 }
 
 // handle mimicks the call signature of the smart contracts.
 // thus it moves params and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn handle<S: Storage + 'static, A: Api + 'static>(
+pub fn handle<S: Storage + 'static, A: Api + 'static, T: Serialize>(
     instance: &mut Instance<S, A>,
     params: Params,
-    msg: Vec<u8>,
+    msg: T,
 ) -> ContractResult {
-    call_handle(instance, &params, &msg).unwrap()
+    let msg = to_vec(&msg);
+    if let Err(e) = msg {
+        return ContractResult::Err(e.to_string());
+    }
+    call_handle(instance, &params, &msg.unwrap()).unwrap()
 }
 
 // query mimicks the call signature of the smart contracts.
 // thus it moves params and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn query<S: Storage + 'static, A: Api + 'static>(
+pub fn query<S: Storage + 'static, A: Api + 'static, T: Serialize>(
     instance: &mut Instance<S, A>,
     msg: Vec<u8>,
 ) -> QueryResult {
-    call_query(instance, &msg).unwrap()
+    let msg = to_vec(&msg);
+    if let Err(e) = msg {
+        return QueryResult::Err(e.to_string());
+    }
+    call_query(instance, &msg.unwrap()).unwrap()
 }

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -110,7 +110,7 @@ fn _do_handle<T: DeserializeOwned>(
     let msg: Vec<u8> = unsafe { consume_slice(msg_ptr)? };
 
     let params: Params = from_slice(&params).context(ParseErr { kind: "Params" })?;
-    let msg: T = from_slice(&msg).context(ParseErr { kind: "InitMsg" })?;
+    let msg: T = from_slice(&msg).context(ParseErr { kind: "HandleMsg" })?;
     let mut deps = dependencies();
     let res = handle_fn(&mut deps, params, msg)?;
     let json = to_vec(&ContractResult::Ok(res)).context(SerializeErr {
@@ -125,7 +125,7 @@ fn _do_query<T: DeserializeOwned>(
 ) -> Result<*mut c_void, Error> {
     let msg: Vec<u8> = unsafe { consume_slice(msg_ptr)? };
 
-    let msg: T = from_slice(&msg).context(ParseErr { kind: "InitMsg" })?;
+    let msg: T = from_slice(&msg).context(ParseErr { kind: "QueryMsg" })?;
     let deps = dependencies();
     let res = query_fn(&deps, msg)?;
     let json = to_vec(&QueryResult::Ok(res)).context(SerializeErr {

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -15,6 +15,7 @@ use crate::memory::{alloc, consume_slice, release_buffer};
 use crate::serde::{from_slice, to_vec};
 use crate::traits::Extern;
 use crate::types::{ContractResult, Params, QueryResult, Response};
+use serde::Deserialize;
 
 // allocate reserves the given number of bytes in wasm memory and returns a pointer
 // to a slice defining this data. This space is managed by the calling process
@@ -33,12 +34,12 @@ pub extern "C" fn deallocate(pointer: *mut c_void) {
 }
 
 // do_init should be wrapped in an external "C" export, containing a contract-specific function as arg
-pub fn do_init<T: Display + From<Error>>(
+pub fn do_init<'de, T: Deserialize<'de>>(
     init_fn: &dyn Fn(
         &mut Extern<ExternalStorage, ExternalApi>,
         Params,
-        Vec<u8>,
-    ) -> Result<Response, T>,
+        T,
+    ) -> Result<Response, Error>,
     params_ptr: *mut c_void,
     msg_ptr: *mut c_void,
 ) -> *mut c_void {
@@ -49,12 +50,12 @@ pub fn do_init<T: Display + From<Error>>(
 }
 
 // do_handle should be wrapped in an external "C" export, containing a contract-specific function as arg
-pub fn do_handle<T: Display + From<Error>>(
+pub fn do_handle<'de, T: Deserialize<'de>>(
     handle_fn: &dyn Fn(
         &mut Extern<ExternalStorage, ExternalApi>,
         Params,
-        Vec<u8>,
-    ) -> Result<Response, T>,
+        T,
+    ) -> Result<Response, Error>,
     params_ptr: *mut c_void,
     msg_ptr: *mut c_void,
 ) -> *mut c_void {
@@ -65,8 +66,8 @@ pub fn do_handle<T: Display + From<Error>>(
 }
 
 // do_query should be wrapped in an external "C" export, containing a contract-specific function as arg
-pub fn do_query<T: Display + From<Error>>(
-    query_fn: &dyn Fn(&Extern<ExternalStorage, ExternalApi>, Vec<u8>) -> Result<Vec<u8>, T>,
+pub fn do_query<'de, T: Deserialize<'de>>(
+    query_fn: &dyn Fn(&Extern<ExternalStorage, ExternalApi>, T) -> Result<Vec<u8>, Error>,
     msg_ptr: *mut c_void,
 ) -> *mut c_void {
     match _do_query(query_fn, msg_ptr) {
@@ -75,19 +76,31 @@ pub fn do_query<T: Display + From<Error>>(
     }
 }
 
-fn _do_init<T: Display + From<Error>>(
+fn _do_init<'de, T: Deserialize<'de>>(
     init_fn: &dyn Fn(
         &mut Extern<ExternalStorage, ExternalApi>,
         Params,
-        Vec<u8>,
-    ) -> Result<Response, T>,
+        T,
+    ) -> Result<Response, Error>,
     params_ptr: *mut c_void,
     msg_ptr: *mut c_void,
-) -> Result<*mut c_void, T> {
+) -> Result<*mut c_void, Error> {
     let params: Vec<u8> = unsafe { consume_slice(params_ptr)? };
     let msg: Vec<u8> = unsafe { consume_slice(msg_ptr)? };
+    __do_init(init_fn, &params, &msg)
+}
 
+fn __do_init<'de, T: Deserialize<'de>>(
+    init_fn: &dyn Fn(
+        &mut Extern<ExternalStorage, ExternalApi>,
+        Params,
+        T,
+    ) -> Result<Response, Error>,
+    params: &[u8],
+    msg: &'de [u8],
+) -> Result<*mut c_void, Error> {
     let params: Params = from_slice(&params).context(ParseErr { kind: "Params" })?;
+    let msg: T = from_slice(&msg).context(ParseErr { kind: "InitMsg" })?;
     let mut deps = dependencies();
     let res = init_fn(&mut deps, params, msg)?;
     let json = to_vec(&ContractResult::Ok(res)).context(SerializeErr {
@@ -96,19 +109,21 @@ fn _do_init<T: Display + From<Error>>(
     Ok(release_buffer(json))
 }
 
-fn _do_handle<T: Display + From<Error>>(
+
+fn _do_handle<'de, T: Deserialize<'de>>(
     handle_fn: &dyn Fn(
         &mut Extern<ExternalStorage, ExternalApi>,
         Params,
-        Vec<u8>,
-    ) -> Result<Response, T>,
+        T,
+    ) -> Result<Response, Error>,
     params_ptr: *mut c_void,
     msg_ptr: *mut c_void,
-) -> Result<*mut c_void, T> {
+) -> Result<*mut c_void, Error> {
     let params: Vec<u8> = unsafe { consume_slice(params_ptr)? };
     let msg: Vec<u8> = unsafe { consume_slice(msg_ptr)? };
 
     let params: Params = from_slice(&params).context(ParseErr { kind: "Params" })?;
+    let msg: T = from_slice(&msg).context(ParseErr { kind: "InitMsg" })?;
     let mut deps = dependencies();
     let res = handle_fn(&mut deps, params, msg)?;
     let json = to_vec(&ContractResult::Ok(res)).context(SerializeErr {
@@ -117,12 +132,13 @@ fn _do_handle<T: Display + From<Error>>(
     Ok(release_buffer(json))
 }
 
-fn _do_query<T: Display + From<Error>>(
-    query_fn: &dyn Fn(&Extern<ExternalStorage, ExternalApi>, Vec<u8>) -> Result<Vec<u8>, T>,
+fn _do_query<'de, T: Deserialize<'de>>(
+    query_fn: &dyn Fn(&Extern<ExternalStorage, ExternalApi>, T) -> Result<Vec<u8>, Error>,
     msg_ptr: *mut c_void,
-) -> Result<*mut c_void, T> {
+) -> Result<*mut c_void, Error> {
     let msg: Vec<u8> = unsafe { consume_slice(msg_ptr)? };
 
+    let msg: T = from_slice(&msg).context(ParseErr { kind: "InitMsg" })?;
     let deps = dependencies();
     let res = query_fn(&deps, msg)?;
     let json = to_vec(&QueryResult::Ok(res)).context(SerializeErr {


### PR DESCRIPTION
Closes #93 

Allows one to use normal types in the contracts - eg.

```rust
pub fn init<S: Storage, A: Api>(
    deps: &mut Extern<S, A>,
    params: Params,
    msg: InitMsg,
) -> Result<Response> {
```

Rather than forcing `msg: Vec<u8>`.

Wasm side, this is handled by use of generics and parsing based on the compilers detection of function parameters.

In test code, we can replace:

```rust
        let msg = to_vec(&InitMsg {
             verifier,
             beneficiary,
        })
        .unwrap();
```

with

```rust
    let msg = InitMsg{verifier, beneficiary};
```

which makes it much smoother.

TODO: update the integration testing code to make similar use of generics