### PR TITLE
Improve key prefix implementation for simple and nested namespaces

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -14,7 +14,8 @@ fn len(prefix: &[u8]) -> [u8; 2] {
     [length_bytes[6], length_bytes[7]]
 }
 
-// prepend length of the namespace
+// Calculates the raw key prefix for a given namespace
+// as documented in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
 fn key_prefix(namespace: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(namespace.len() + 2);
     out.extend_from_slice(&len(namespace));
@@ -22,6 +23,8 @@ fn key_prefix(namespace: &[u8]) -> Vec<u8> {
     out
 }
 
+// Calculates the raw key prefix for a given nested namespace
+// as documented in https://github.com/webmaster128/key-namespacing#nesting
 fn multi_key_prefix(namespaces: &[&[u8]]) -> Vec<u8> {
     let mut size = namespaces.len();
     for &namespace in namespaces {

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -25,7 +25,7 @@ fn key_prefix(namespace: &[u8]) -> Vec<u8> {
 
 // Calculates the raw key prefix for a given nested namespace
 // as documented in https://github.com/webmaster128/key-namespacing#nesting
-fn multi_key_prefix(namespaces: &[&[u8]]) -> Vec<u8> {
+fn key_prefix_nested(namespaces: &[&[u8]]) -> Vec<u8> {
     let mut size = namespaces.len();
     for &namespace in namespaces {
         size += namespace.len() + 2;
@@ -56,7 +56,7 @@ impl<'a, T: ReadonlyStorage> ReadonlyPrefixedStorage<'a, T> {
     // before exposing any of these demo apis
     fn multilevel(prefixes: &[&[u8]], storage: &'a T) -> Self {
         ReadonlyPrefixedStorage {
-            prefix: multi_key_prefix(prefixes),
+            prefix: key_prefix_nested(prefixes),
             storage,
         }
     }
@@ -87,7 +87,7 @@ impl<'a, T: Storage> PrefixedStorage<'a, T> {
     // before exposing any of these demo apis
     fn multilevel(prefixes: &[&[u8]], storage: &'a mut T) -> Self {
         PrefixedStorage {
-            prefix: multi_key_prefix(prefixes),
+            prefix: key_prefix_nested(prefixes),
             storage,
         }
     }
@@ -149,15 +149,15 @@ mod test {
     }
 
     #[test]
-    fn multi_key_prefix_works() {
-        assert_eq!(multi_key_prefix(&[]), b"");
-        assert_eq!(multi_key_prefix(&[b""]), b"\x00\x00");
-        assert_eq!(multi_key_prefix(&[b"", b""]), b"\x00\x00\x00\x00");
+    fn key_prefix_nested_works() {
+        assert_eq!(key_prefix_nested(&[]), b"");
+        assert_eq!(key_prefix_nested(&[b""]), b"\x00\x00");
+        assert_eq!(key_prefix_nested(&[b"", b""]), b"\x00\x00\x00\x00");
 
-        assert_eq!(multi_key_prefix(&[b"a"]), b"\x00\x01a");
-        assert_eq!(multi_key_prefix(&[b"a", b"ab"]), b"\x00\x01a\x00\x02ab");
+        assert_eq!(key_prefix_nested(&[b"a"]), b"\x00\x01a");
+        assert_eq!(key_prefix_nested(&[b"a", b"ab"]), b"\x00\x01a\x00\x02ab");
         assert_eq!(
-            multi_key_prefix(&[b"a", b"ab", b"abc"]),
+            key_prefix_nested(&[b"a", b"ab", b"abc"]),
             b"\x00\x01a\x00\x02ab\x00\x03abc"
         );
     }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -54,9 +54,9 @@ impl<'a, T: ReadonlyStorage> ReadonlyPrefixedStorage<'a, T> {
 
     // note: multilevel is here for demonstration purposes, but may well be removed
     // before exposing any of these demo apis
-    fn multilevel(prefixes: &[&[u8]], storage: &'a T) -> Self {
+    fn multilevel(namespaces: &[&[u8]], storage: &'a T) -> Self {
         ReadonlyPrefixedStorage {
-            prefix: key_prefix_nested(prefixes),
+            prefix: key_prefix_nested(namespaces),
             storage,
         }
     }
@@ -85,9 +85,9 @@ impl<'a, T: Storage> PrefixedStorage<'a, T> {
 
     // note: multilevel is here for demonstration purposes, but may well be removed
     // before exposing any of these demo apis
-    fn multilevel(prefixes: &[&[u8]], storage: &'a mut T) -> Self {
+    fn multilevel(namespaces: &[&[u8]], storage: &'a mut T) -> Self {
         PrefixedStorage {
-            prefix: key_prefix_nested(prefixes),
+            prefix: key_prefix_nested(namespaces),
             storage,
         }
     }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -52,8 +52,8 @@ impl<'a, T: ReadonlyStorage> ReadonlyPrefixedStorage<'a, T> {
         }
     }
 
-    // note: multilevel is here for demonstration purposes, but may well be removed
-    // before exposing any of these demo apis
+    // Nested namespaces as documented in
+    // https://github.com/webmaster128/key-namespacing#nesting
     fn multilevel(namespaces: &[&[u8]], storage: &'a T) -> Self {
         ReadonlyPrefixedStorage {
             prefix: key_prefix_nested(namespaces),
@@ -83,8 +83,8 @@ impl<'a, T: Storage> PrefixedStorage<'a, T> {
         }
     }
 
-    // note: multilevel is here for demonstration purposes, but may well be removed
-    // before exposing any of these demo apis
+    // Nested namespaces as documented in
+    // https://github.com/webmaster128/key-namespacing#nesting
     fn multilevel(namespaces: &[&[u8]], storage: &'a mut T) -> Self {
         PrefixedStorage {
             prefix: key_prefix_nested(namespaces),

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -121,9 +121,20 @@ mod test {
 
     #[test]
     fn key_prefix_works_for_long_prefix() {
-        let limit = 0xFFFF;
-        let long_namespace = vec![0; limit];
-        key_prefix(&long_namespace);
+        let long_namespace1 = vec![0; 256];
+        let prefix1 = key_prefix(&long_namespace1);
+        assert_eq!(prefix1.len(), 256 + 2);
+        assert_eq!(&prefix1[0..2], b"\x01\x00");
+
+        let long_namespace2 = vec![0; 30000];
+        let prefix2 = key_prefix(&long_namespace2);
+        assert_eq!(prefix2.len(), 30000 + 2);
+        assert_eq!(&prefix2[0..2], b"\x75\x30");
+
+        let long_namespace3 = vec![0; 0xFFFF];
+        let prefix3 = key_prefix(&long_namespace3);
+        assert_eq!(prefix3.len(), 0xFFFF + 2);
+        assert_eq!(&prefix3[0..2], b"\xFF\xFF");
     }
 
     #[test]


### PR DESCRIPTION
The documentation of https://github.com/webmaster128/key-namespacing#length-prefixed-keys was improved, especially regarding nesting.

Application provided namespaces are now called namespaces consistently (hopefully) and the fact that something is a prefix should be considered implementation detail. I.e. "key prefix" referes to the implementation side of the "namespace".

Implementation improvements:
- Namespaces can now be up to 65535 bytes long
- `key_prefix_nested` is now implemented using `key_prefix` to be DRY
- Vector capacity calculation in `key_prefix_nested` fixed
- Unit tests for `key_prefix` and `key_prefix_nested` added