### PR TITLE
Add more error types

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,7 +45,7 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
-    #[snafu(display("Item Not Found"))]
+    #[snafu(display("{} not found", kind))]
     NotFound {
         kind: &'static str,
         #[cfg(feature = "backtraces")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,6 +45,12 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    #[snafu(display("Item Not Found"))]
+    NotFound {
+        kind: &'static str,
+        #[cfg(feature = "backtraces")]
+        backtrace: snafu::Backtrace,
+    },
 }
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;


### PR DESCRIPTION
A few generic errors I found to be useful while working on other libraries:

* `NotFound` when no data is available for a read

Desired:

* Derive `PartialEq` on `Error` for easier testing (eg. `assert_eq!(result, Ok(None))`)
-> This seems to be impossible because some source errors don't implement PartialEq, I guess we would need a hand-rolled solution if desired