### PR TITLE
Add ValidationErr to CosmWasm

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,7 +51,7 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
-    #[snafu(display("Invalid {}: {}", kind, msg))]
+    #[snafu(display("Invalid {}: {}", field, msg))]
     ValidationErr {
         field: &'static str,
         msg: &'static str,
@@ -61,3 +61,25 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
+
+pub fn invalid<T>(field: &'static str, msg: &'static str) -> Result<T> {
+    ValidationErr { field, msg }.fail()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn use_invalid() {
+        let e: Result<()> = invalid("demo", "not implemented");
+        match e {
+            Err(Error::ValidationErr { field, msg, .. }) => {
+                assert_eq!(field, "demo");
+                assert_eq!(msg, "not implemented");
+            }
+            Err(e) => panic!("unexpected error, {:?}", e),
+            Ok(_) => panic!("invalid must return error"),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,24 @@ use snafu::Snafu;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub")]
 pub enum Error {
+    #[snafu(display("Contract error: {}", msg))]
+    ContractErr {
+        msg: &'static str,
+        #[cfg(feature = "backtraces")]
+        backtrace: snafu::Backtrace,
+    },
+    #[snafu(display("Contract error: {}", msg))]
+    DynContractErr {
+        msg: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: snafu::Backtrace,
+    },
+    #[snafu(display("{} not found", kind))]
+    NotFound {
+        kind: &'static str,
+        #[cfg(feature = "backtraces")]
+        backtrace: snafu::Backtrace,
+    },
     #[snafu(display("Received null pointer, refuse to use"))]
     NullPointer {
         #[cfg(feature = "backtraces")]
@@ -22,18 +40,6 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
-    #[snafu(display("Contract error: {}", msg))]
-    ContractErr {
-        msg: &'static str,
-        #[cfg(feature = "backtraces")]
-        backtrace: snafu::Backtrace,
-    },
-    #[snafu(display("Contract error: {}", msg))]
-    DynContractErr {
-        msg: String,
-        #[cfg(feature = "backtraces")]
-        backtrace: snafu::Backtrace,
-    },
     #[snafu(display("UTF8 encoding error: {}", source))]
     Utf8Err {
         source: std::str::Utf8Error,
@@ -45,9 +51,10 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
-    #[snafu(display("{} not found", kind))]
-    NotFound {
-        kind: &'static str,
+    #[snafu(display("Invalid {}: {}", kind, msg))]
+    ValidationErr {
+        field: &'static str,
+        msg: &'static str,
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },


### PR DESCRIPTION
A custom type (for easier checks), inspired by the validation checks in `cw-erc20`: https://github.com/confio/cosmwasm-examples/blob/master/erc20/src/contract/mod.rs#L102-L119

Adds: 

```rust
    #[snafu(display("Invalid {}: {}", kind, msg))]
    ValidationErr {
        field: &'static str,
        msg: &'static str,
        #[cfg(feature = "backtraces")]
        backtrace: snafu::Backtrace,
    },
```

as well as an `invalid()` helper to create this.

Current usage:

```rust
    if !is_valid_name(&msg.name) {
        return ContractErr {
            msg: "Name is not in the expected format (3-30 UTF-8 bytes)",
        }
        .fail();
    }
```

New Usage:

```rust
    if !is_valid_name(&msg.name) {
        return invalid("InitMsg.Name", "expected format 3-30 UTF-8 bytes");
    }
```

Less typing and more standardized types/messages for debugging