### PR TITLE
Make CosmosMsg::Contract.send optional

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -110,7 +110,7 @@ pub enum CosmosMsg {
     Contract {
         contract_addr: HumanAddr,
         msg: String,
-        send: Vec<Coin>,
+        send: Option<Vec<Coin>>,
     },
     // this should never be created here, just passed in from the user and later dispatched
     Opaque {


### PR DESCRIPTION
Unlike `CosmosMsg::Send.amount`, and like `Params.message.sent_funds`, the amount to send between contracts may be empty. 

Go likes to encode empty arrays as `null`, and the rust parse requires at least `[]` unless we make it `Option<Vec<T>>`. Thus, we add the option to allow consistent parsing when no tokens are sent.

This is a minor break to any contracts creating such `CosmosMsg::Contract`, but I don't think anyone has used it (they haven't complained). The json format is identical, so the external API is no affected.