### PR TITLE
Fix missing error propagation of write_data calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - Remove export `cosmwasm_vm::read_memory`. Using this indicates an
   architectural flaw, since this is a method for host to guest communication
   inside the VM and not needed for users of the VM.
+- Create new type `cosmwasm_vm:errors::ExecutionErr`.
+- Change return type of `cosmwasm_vm::write_memory` to `Result<usize, Error>` to
+  make it harder to forget handling errors.
+- Fix missing error propagation in `do_canonical_address`, `do_human_address`
+  and `allocate`.
 - Add `cosmwasm_vm::testing::test_io` for basic memory allocation/deallocation
   testing between host and guest.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@
 - Remove export `cosmwasm_vm::read_memory`. Using this indicates an
   architectural flaw, since this is a method for host to guest communication
   inside the VM and not needed for users of the VM.
-- Create new type `cosmwasm_vm:errors::ExecutionErr`.
+- Create new type `cosmwasm_vm:errors::Error::RegionTooSmallErr`.
 - Change return type of `cosmwasm_vm::write_memory` to `Result<usize, Error>` to
   make it harder to forget handling errors.
 - Fix missing error propagation in `do_canonical_address`, `do_human_address`
   and `allocate`.
+- Update error return codes in import `c_read`.
 - Add `cosmwasm_vm::testing::test_io` for basic memory allocation/deallocation
   testing between host and guest.
 

--- a/lib/vm/src/context.rs
+++ b/lib/vm/src/context.rs
@@ -15,12 +15,12 @@ use cosmwasm::types::{CanonicalAddr, HumanAddr};
 /// An undocumented, unstable constant. This can change at any time. Be warned.
 static WRITE_REGION_ERROR: i32 = -1001;
 
-pub fn do_read<T: Storage>(ctx: &mut Ctx, key_ptr: u32, val_ptr: u32) -> i32 {
+pub fn do_read<T: Storage>(ctx: &Ctx, key_ptr: u32, value_ptr: u32) -> i32 {
     let key = read_region(ctx, key_ptr);
     let mut value: Option<Vec<u8>> = None;
     with_storage_from_context(ctx, |store: &mut T| value = store.get(&key));
     match value {
-        Some(buf) => match write_region(ctx, val_ptr, &buf) {
+        Some(buf) => match write_region(ctx, value_ptr, &buf) {
             Ok(bytes_written) => bytes_written.try_into().unwrap(),
             Err(_) => WRITE_REGION_ERROR,
         },
@@ -28,9 +28,9 @@ pub fn do_read<T: Storage>(ctx: &mut Ctx, key_ptr: u32, val_ptr: u32) -> i32 {
     }
 }
 
-pub fn do_write<T: Storage>(ctx: &mut Ctx, key: u32, value: u32) {
-    let key = read_region(ctx, key);
-    let value = read_region(ctx, value);
+pub fn do_write<T: Storage>(ctx: &Ctx, key_ptr: u32, value_ptr: u32) {
+    let key = read_region(ctx, key_ptr);
+    let value = read_region(ctx, value_ptr);
     with_storage_from_context(ctx, |store: &mut T| store.set(&key, &value));
 }
 

--- a/lib/vm/src/context.rs
+++ b/lib/vm/src/context.rs
@@ -1,6 +1,7 @@
 /**
 Internal details to be used by instance.rs only
 **/
+use std::convert::TryInto;
 use std::ffi::c_void;
 use std::mem;
 
@@ -11,12 +12,18 @@ use cosmwasm::traits::{Api, Storage};
 use crate::memory::{read_region, write_region};
 use cosmwasm::types::{CanonicalAddr, HumanAddr};
 
+/// An undocumented, unstable constant. This can change at any time. Be warned.
+static WRITE_REGION_ERROR: i32 = -1001;
+
 pub fn do_read<T: Storage>(ctx: &mut Ctx, key_ptr: u32, val_ptr: u32) -> i32 {
     let key = read_region(ctx, key_ptr);
     let mut value: Option<Vec<u8>> = None;
     with_storage_from_context(ctx, |store: &mut T| value = store.get(&key));
     match value {
-        Some(buf) => write_region(ctx, val_ptr, &buf),
+        Some(buf) => match write_region(ctx, val_ptr, &buf) {
+            Ok(bytes_written) => bytes_written.try_into().unwrap(),
+            Err(_) => WRITE_REGION_ERROR,
+        },
         None => 0,
     }
 }
@@ -39,10 +46,10 @@ pub fn do_canonical_address<A: Api>(
         Err(_) => return -2,
     };
     match api.canonical_address(&human) {
-        Ok(canon) => {
-            write_region(ctx, canonical_ptr, canon.as_bytes());
-            canon.len() as i32
-        }
+        Ok(canon) => match write_region(ctx, canonical_ptr, canon.as_bytes()) {
+            Ok(bytes_written) => bytes_written.try_into().unwrap(),
+            Err(_) => WRITE_REGION_ERROR,
+        },
         Err(_) => -1,
     }
 }
@@ -50,11 +57,10 @@ pub fn do_canonical_address<A: Api>(
 pub fn do_human_address<A: Api>(api: A, ctx: &mut Ctx, canonical_ptr: u32, human_ptr: u32) -> i32 {
     let canon = read_region(ctx, canonical_ptr);
     match api.human_address(&CanonicalAddr(canon)) {
-        Ok(human) => {
-            let bz = human.as_str().as_bytes();
-            write_region(ctx, human_ptr, bz);
-            bz.len() as i32
-        }
+        Ok(human) => match write_region(ctx, human_ptr, human.as_str().as_bytes()) {
+            Ok(bytes_written) => bytes_written.try_into().unwrap(),
+            Err(_) => WRITE_REGION_ERROR,
+        },
         Err(_) => -1,
     }
 }

--- a/lib/vm/src/errors.rs
+++ b/lib/vm/src/errors.rs
@@ -55,10 +55,10 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
-    // Similar to RuntimeErr but with custom message
-    #[snafu(display("Error during wasm execution: {}", msg))]
-    ExecutionErr {
-        msg: &'static str,
+    #[snafu(display("Region too small. Got {}, required {}", size, required))]
+    RegionTooSmallErr {
+        size: usize,
+        required: usize,
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },

--- a/lib/vm/src/errors.rs
+++ b/lib/vm/src/errors.rs
@@ -55,6 +55,13 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    // Similar to RuntimeErr but with custom message
+    #[snafu(display("Error during wasm execution: {}", msg))]
+    ExecutionErr {
+        msg: &'static str,
+        #[cfg(feature = "backtraces")]
+        backtrace: snafu::Backtrace,
+    },
     #[snafu(display("Validating Wasm: {}", msg))]
     ValidationErr {
         msg: &'static str,

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use snafu::ResultExt;
 pub use wasmer_runtime_core::typed_func::Func;
 use wasmer_runtime_core::{
-    func, imports,
+    imports,
     module::Module,
     typed_func::{Wasm, WasmTypeList},
     vm::Ctx,
@@ -41,8 +41,12 @@ where
         let import_obj = imports! {
             || { setup_context::<S>() },
             "env" => {
-                "c_read" => func!(do_read::<S>),
-                "c_write" => func!(do_write::<S>),
+                "c_read" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
+                    do_read::<S>(ctx, key_ptr, value_ptr)
+                }),
+                "c_write" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| {
+                    do_write::<S>(ctx, key_ptr, value_ptr)
+                }),
                 // Reads human address from human_ptr and writes canonicalized representation to canonical_ptr.
                 // A prepared and sufficiently large memory Region is expected at canonical_ptr that points to pre-allocated memory.
                 // Returns negative value on error. Returns length of the canoncal address on success.

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -43,9 +43,17 @@ where
             "env" => {
                 "c_read" => func!(do_read::<S>),
                 "c_write" => func!(do_write::<S>),
+                // Reads human address from human_ptr and writes canonicalized representation to canonical_ptr.
+                // A prepared and sufficiently large memory Region is expected at canonical_ptr that points to pre-allocated memory.
+                // Returns negative value on error. Returns length of the canoncal address on success.
+                // Ownership of both input and output pointer is not transferred to the host.
                 "c_canonical_address" => Func::new(move |ctx: &mut Ctx, human_ptr: u32, canonical_ptr: u32| -> i32 {
                     do_canonical_address(api, ctx, human_ptr, canonical_ptr)
                 }),
+                // Reads canonical address from canonical_ptr and writes humanized representation to human_ptr.
+                // A prepared and sufficiently large memory Region is expected at human_ptr that points to pre-allocated memory.
+                // Returns negative value on error. Returns length of the human address on success.
+                // Ownership of both input and output pointer is not transferred to the host.
                 "c_human_address" => Func::new(move |ctx: &mut Ctx, canonical_ptr: u32, human_ptr: u32| -> i32 {
                     do_human_address(api, ctx, canonical_ptr, human_ptr)
                 }),

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -43,7 +43,8 @@ where
             "env" => {
                 // Reads the database entry at the given key into the the value.
                 // A prepared and sufficiently large memory Region is expected at value_ptr that points to pre-allocated memory.
-                // Returns negative value on error. Returns length of the value in bytes on success.
+                // Returns length of the value in bytes on success. Returns negative value on error. An incomplete list of error codes is:
+                //   value region too small: -1000002
                 // Ownership of both input and output pointer is not transferred to the host.
                 "c_read" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
                     do_read::<S>(ctx, key_ptr, value_ptr)

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -41,9 +41,15 @@ where
         let import_obj = imports! {
             || { setup_context::<S>() },
             "env" => {
+                // Reads the database entry at the given key into the the value.
+                // A prepared and sufficiently large memory Region is expected at value_ptr that points to pre-allocated memory.
+                // Returns negative value on error. Returns length of the value in bytes on success.
+                // Ownership of both input and output pointer is not transferred to the host.
                 "c_read" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| -> i32 {
                     do_read::<S>(ctx, key_ptr, value_ptr)
                 }),
+                // Writes the given value into the database entry at the given key.
+                // Ownership of both input and output pointer is not transferred to the host.
                 "c_write" => Func::new(move |ctx: &mut Ctx, key_ptr: u32, value_ptr: u32| {
                     do_write::<S>(ctx, key_ptr, value_ptr)
                 }),

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -90,7 +90,7 @@ where
     pub fn allocate(&mut self, data: &[u8]) -> Result<u32> {
         let alloc: Func<u32, u32> = self.func("allocate")?;
         let ptr = alloc.call(data.len() as u32).context(RuntimeErr {})?;
-        write_region(self.instance.context(), ptr, data);
+        write_region(self.instance.context(), ptr, data)?;
         Ok(ptr)
     }
 

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -27,14 +27,13 @@ pub fn read_region(ctx: &Ctx, ptr: u32) -> Vec<u8> {
     let region = to_region(ctx, ptr);
     let memory = ctx.memory(0);
 
-    // TODO: there must be a faster way to copy memory
     match WasmPtr::<u8, Array>::new(region.offset).deref(memory, 0, region.len) {
         Some(cells) => {
+            // In case you want to do some premature optimization, this shows how to cast a `&'mut [Cell<u8>]` to `&mut [u8]`:
+            // https://github.com/wasmerio/wasmer/blob/0.13.1/lib/wasi/src/syscalls/mod.rs#L79-L81
             let len = region.len as usize;
             let mut result = vec![0u8; len];
             for i in 0..len {
-                // result[i] = unsafe { cells.get_unchecked(i).get() }
-                // resolved to memcpy, but only if we really start copying huge arrays
                 result[i] = cells[i].get();
             }
             result
@@ -66,9 +65,10 @@ pub fn write_region(ctx: &Ctx, ptr: u32, data: &[u8]) -> Result<usize, Error> {
 
     let memory = ctx.memory(0);
 
-    // TODO: there must be a faster way to copy memory
     match unsafe { WasmPtr::<u8, Array>::new(region.offset).deref_mut(memory, 0, region.len) } {
         Some(cells) => {
+            // In case you want to do some premature optimization, this shows how to cast a `&'mut [Cell<u8>]` to `&mut [u8]`:
+            // https://github.com/wasmerio/wasmer/blob/0.13.1/lib/wasi/src/syscalls/mod.rs#L79-L81
             for i in 0..data.len() {
                 cells[i].set(data[i])
             }

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -1,4 +1,4 @@
-use crate::errors::{Error, ExecutionErr};
+use crate::errors::{Error, RegionTooSmallErr};
 use wasmer_runtime_core::{
     memory::ptr::{Array, WasmPtr},
     types::ValueType,
@@ -51,9 +51,12 @@ pub fn read_region(ctx: &Ctx, ptr: u32) -> Vec<u8> {
 /// Returns number of bytes written on success.
 pub fn write_region(ctx: &Ctx, ptr: u32, data: &[u8]) -> Result<usize, Error> {
     let region = to_region(ctx, ptr);
-    if data.len() > (region.len as usize) {
-        return ExecutionErr {
-            msg: "Region is not sufficiently large to store the given data",
+    let region_size = region.len as usize;
+
+    if data.len() > region_size {
+        return RegionTooSmallErr {
+            size: region_size,
+            required: data.len(),
         }
         .fail();
     }

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -65,7 +65,7 @@ pub fn write_region(ctx: &Ctx, ptr: u32, data: &[u8]) -> Result<usize, Error> {
 
     let memory = ctx.memory(0);
 
-    match unsafe { WasmPtr::<u8, Array>::new(region.offset).deref_mut(memory, 0, region.len) } {
+    match WasmPtr::<u8, Array>::new(region.offset).deref(memory, 0, region.len) {
         Some(cells) => {
             // In case you want to do some premature optimization, this shows how to cast a `&'mut [Cell<u8>]` to `&mut [u8]`:
             // https://github.com/wasmerio/wasmer/blob/0.13.1/lib/wasi/src/syscalls/mod.rs#L79-L81

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -52,9 +52,11 @@ impl ReadonlyStorage for ExternalStorage {
         let value = alloc(MAX_READ);
 
         let read = unsafe { c_read(key_ptr, value) };
-        if read < 0 {
-            // TODO: try to read again with larger amount
-            panic!("needed to read more data")
+        if read == -1000002 {
+            panic!("Allocated memory too small to hold the database value for the given key. \
+                If this is causing trouble for you, have a look at https://github.com/confio/cosmwasm/issues/126");
+        } else if read < 0 {
+            panic!("An unknown error occurred in the c_read call.")
         } else if read == 0 {
             return None;
         }


### PR DESCRIPTION
Before this, it was so easy to forget handling errors of `write_data` calls that we did it in 3 places.