### PR TITLE
Update hackatom build instructions

### DIFF
--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -27,9 +27,6 @@ backtraces = [ "cosmwasm/backtraces", "cosmwasm-vm/backtraces" ]
 
 [dependencies]
 cosmwasm = { path = "../..", version = "0.6.3" }
-# To make optimized builds (cosmwasm-opt) you need to refer to external deps, not path refs outside of docker
-#cosmwasm = { git = "https://github.com/confio/cosmwasm", branch = "dummy-0.6-marker" }
-#cosmwasm = { version = "0.6.3" }
 schemars = "0.5"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.5.0", default-features = false, features = ["rust_1_30"] }
@@ -38,7 +35,6 @@ wasm-bindgen = "0.2.55"
 
 [dev-dependencies]
 cosmwasm-vm = { path = "../../lib/vm", version = "0.6.3" }
-# To make optimized builds (cosmwasm-opt) you need to refer to external deps, not path refs outside of docker
-#cosmwasm-vm = { git = "https://github.com/confio/cosmwasm", branch = "dummy-0.6-marker", default-features = false, features = ["default-cranelift"] }
-#cosmwasm-vm = { version = "0.6.3", default-features = false, features = ["default-cranelift"] }
+# To make optimized builds with cosmwasm-opt you need use Rust stable and the following line
+# cosmwasm-vm = { path = "../../lib/vm", version = "0.6.3", default-features = false, features = ["default-cranelift"] }
 serde_json = "1.0"

--- a/lib/vm/README.md
+++ b/lib/vm/README.md
@@ -2,7 +2,7 @@
 
 This is an abstraction layer around the wasmer VM to expose just what
 we need to run cosmwasm contracts in a high-level manner.
-This is intended both for efficient writing of unit tests, as well as a 
+This is intended both for efficient writing of unit tests, as well as a
 public API to run contracts in eg. go-cosmwasm. As such it includes all
 glue code needed for typical actions, like fs caching.
 
@@ -12,3 +12,13 @@ There is a demo file in `testdata/contract.wasm` - this is a compiled and
 optimized version of [contracts/hackatom](https://github.com/confio/cosmwasm/tree/master/contracts/hackatom)
 run through [cosmwasm-opt](https://github.com/confio/cosmwasm-opt).
 
+To rebuild the test contract, go to the repo root and do
+
+```sh
+docker run --rm -v $(pwd):/code \
+  --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  confio/cosmwasm-opt:0.6.2 ./contracts/hackatom
+cp contracts/hackatom/target/wasm32-unknown-unknown/release/hackatom.wasm \
+  lib/vm/testdata/contract_0.7.wasm
+```


### PR DESCRIPTION
Update  build instructions for hackatom to not require committing and pushing changes before they can be tested in VM.

Requires cosmwasm-opt 0.6.2 to be on Dockerhub.