### PR TITLE
Params to env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Rename `Slice` to `Region` to simplify differentiation between Wasm memory
   region and serde's `from_slice`
+- Rename `Params` to `Env`, `mock_params` to `mock_env` for clearer naming
+  (this is information on the execution environment)
 
 **cosmwasm_vm**
 

--- a/contracts/hackatom/src/contract.rs
+++ b/contracts/hackatom/src/contract.rs
@@ -5,7 +5,7 @@ use snafu::{OptionExt, ResultExt};
 use cosmwasm::errors::{unauthorized, NotFound, ParseErr, Result, SerializeErr};
 use cosmwasm::serde::{from_slice, to_vec};
 use cosmwasm::traits::{Api, Extern, Storage};
-use cosmwasm::types::{CanonicalAddr, CosmosMsg, HumanAddr, Env, Response};
+use cosmwasm::types::{CanonicalAddr, CosmosMsg, Env, HumanAddr, Response};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InitMsg {
@@ -256,8 +256,7 @@ mod tests {
         assert_eq!(0, init_res.messages.len());
 
         // beneficiary can release it
-        let handle_params =
-            mock_env(&deps.api, beneficiary.as_str(), &[], &coin("1000", "earth"));
+        let handle_params = mock_env(&deps.api, beneficiary.as_str(), &[], &coin("1000", "earth"));
         let handle_res = handle(&mut deps, handle_params, HandleMsg {});
         assert!(handle_res.is_err());
 

--- a/contracts/hackatom/src/lib.rs
+++ b/contracts/hackatom/src/lib.rs
@@ -14,19 +14,19 @@ mod wasm {
     use std::ffi::c_void;
 
     #[no_mangle]
-    pub extern "C" fn init(params_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+    pub extern "C" fn init(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
         exports::do_init(
             &contract::init::<imports::ExternalStorage, imports::ExternalApi>,
-            params_ptr,
+            env_ptr,
             msg_ptr,
         )
     }
 
     #[no_mangle]
-    pub extern "C" fn handle(params_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
+    pub extern "C" fn handle(env_ptr: *mut c_void, msg_ptr: *mut c_void) -> *mut c_void {
         exports::do_handle(
             &contract::handle::<imports::ExternalStorage, imports::ExternalApi>,
-            params_ptr,
+            env_ptr,
             msg_ptr,
         )
     }

--- a/contracts/hackatom/tests/integration.rs
+++ b/contracts/hackatom/tests/integration.rs
@@ -1,6 +1,6 @@
 use std::str::from_utf8;
 
-use cosmwasm::mock::mock_params;
+use cosmwasm::mock::mock_env;
 use cosmwasm::serde::from_slice;
 use cosmwasm::traits::{Api, ReadonlyStorage};
 use cosmwasm::types::{coin, CosmosMsg, HumanAddr, QueryResult};
@@ -51,8 +51,8 @@ fn proper_initialization() {
         verifier,
         beneficiary,
     };
-    let params = mock_params(&deps.api, "creator", &coin("1000", "earth"), &[]);
-    let res = init(&mut deps, params, msg).unwrap();
+    let env = mock_env(&deps.api, "creator", &coin("1000", "earth"), &[]);
+    let res = init(&mut deps, env, msg).unwrap();
     assert_eq!(0, res.messages.len());
 
     // it worked, let's check the state
@@ -74,8 +74,8 @@ fn init_and_query() {
         verifier: verifier.clone(),
         beneficiary,
     };
-    let params = mock_params(&deps.api, creator.as_str(), &coin("1000", "earth"), &[]);
-    let res = init(&mut deps, params, msg).unwrap();
+    let env = mock_env(&deps.api, creator.as_str(), &coin("1000", "earth"), &[]);
+    let res = init(&mut deps, env, msg).unwrap();
     assert_eq!(0, res.messages.len());
 
     // now let's query
@@ -94,9 +94,9 @@ fn init_and_query() {
 #[test]
 fn fails_on_bad_init() {
     let mut deps = mock_instance(WASM);
-    let params = mock_params(&deps.api, "creator", &coin("1000", "earth"), &[]);
+    let env = mock_env(&deps.api, "creator", &coin("1000", "earth"), &[]);
     // bad init returns parse error (pass wrong type - this connection is not enforced)
-    let res = init(&mut deps, params, HandleMsg {});
+    let res = init(&mut deps, env, HandleMsg {});
     assert_eq!(true, res.is_err());
 }
 
@@ -112,23 +112,23 @@ fn proper_handle() {
         verifier: verifier.clone(),
         beneficiary: beneficiary.clone(),
     };
-    let init_params = mock_params(
+    let init_env = mock_env(
         &deps.api,
         "creator",
         &coin("1000", "earth"),
         &coin("1000", "earth"),
     );
-    let init_res = init(&mut deps, init_params, init_msg).unwrap();
+    let init_res = init(&mut deps, init_env, init_msg).unwrap();
     assert_eq!(0, init_res.messages.len());
 
     // beneficiary can release it
-    let handle_params = mock_params(
+    let handle_env = mock_env(
         &deps.api,
         verifier.as_str(),
         &coin("15", "earth"),
         &coin("1015", "earth"),
     );
-    let handle_res = handle(&mut deps, handle_params, HandleMsg {}).unwrap();
+    let handle_res = handle(&mut deps, handle_env, HandleMsg {}).unwrap();
     assert_eq!(1, handle_res.messages.len());
     let msg = handle_res.messages.get(0).expect("no message");
     assert_eq!(
@@ -158,18 +158,18 @@ fn failed_handle() {
         verifier: verifier.clone(),
         beneficiary: beneficiary.clone(),
     };
-    let init_params = mock_params(
+    let init_env = mock_env(
         &deps.api,
         creator.as_str(),
         &coin("1000", "earth"),
         &coin("1000", "earth"),
     );
-    let init_res = init(&mut deps, init_params, init_msg).unwrap();
+    let init_res = init(&mut deps, init_env, init_msg).unwrap();
     assert_eq!(0, init_res.messages.len());
 
     // beneficiary can release it
-    let handle_params = mock_params(&deps.api, beneficiary.as_str(), &[], &coin("1000", "earth"));
-    let handle_res = handle(&mut deps, handle_params, HandleMsg {});
+    let handle_env = mock_env(&deps.api, beneficiary.as_str(), &[], &coin("1000", "earth"));
+    let handle_res = handle(&mut deps, handle_env, HandleMsg {});
     assert!(handle_res.is_err());
 
     // state should not change

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -12,7 +12,7 @@ fn main() {
     create_dir_all(&pwd).unwrap();
 
     let schema = schema_for!(Env);
-    export_schema(&schema, &pwd, "params.json");
+    export_schema(&schema, &pwd, "env.json");
 
     let schema = schema_for!(CosmosMsg);
     export_schema(&schema, &pwd, "cosmos_msg.json");

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -4,14 +4,14 @@ use std::path::PathBuf;
 
 use schemars::{schema::RootSchema, schema_for};
 
-use cosmwasm::types::{ContractResult, CosmosMsg, Params};
+use cosmwasm::types::{ContractResult, CosmosMsg, Env};
 
 fn main() {
     let mut pwd = current_dir().unwrap();
     pwd.push("schema");
     create_dir_all(&pwd).unwrap();
 
-    let schema = schema_for!(Params);
+    let schema = schema_for!(Env);
     export_schema(&schema, &pwd, "params.json");
 
     let schema = schema_for!(CosmosMsg);

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -157,11 +157,11 @@ mod test {
         let mut instance = cache.get_instance(&id, deps).unwrap();
 
         // run contract
-        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
 
         // call and check
-        let res = call_init(&mut instance, &params, msg).unwrap();
+        let res = call_init(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
     }
@@ -175,21 +175,21 @@ mod test {
         let mut instance = cache.get_instance(&id, deps).unwrap();
 
         // init contract
-        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        let res = call_init(&mut instance, &params, msg).unwrap();
+        let res = call_init(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
 
         // run contract - just sanity check - results validate in contract unit tests
-        let params = mock_env(
+        let env = mock_env(
             &instance.api,
             "verifies",
             &coin("15", "earth"),
             &coin("1015", "earth"),
         );
         let msg = b"{}";
-        let res = call_handle(&mut instance, &params, msg).unwrap();
+        let res = call_handle(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
     }
@@ -206,46 +206,46 @@ mod test {
 
         // init instance 1
         let mut instance = cache.get_instance(&id, deps1).unwrap();
-        let params = mock_env(&instance.api, "owner1", &coin("1000", "earth"), &[]);
+        let env = mock_env(&instance.api, "owner1", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "sue", "beneficiary": "mary"}"#.as_bytes();
-        let res = call_init(&mut instance, &params, msg).unwrap();
+        let res = call_init(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
         let deps1 = cache.store_instance(&id, instance).unwrap();
 
         // init instance 2
         let mut instance = cache.get_instance(&id, deps2).unwrap();
-        let params = mock_env(&instance.api, "owner2", &coin("500", "earth"), &[]);
+        let env = mock_env(&instance.api, "owner2", &coin("500", "earth"), &[]);
         let msg = r#"{"verifier": "bob", "beneficiary": "john"}"#.as_bytes();
-        let res = call_init(&mut instance, &params, msg).unwrap();
+        let res = call_init(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
         let deps2 = cache.store_instance(&id, instance).unwrap();
 
         // run contract 2 - just sanity check - results validate in contract unit tests
         let mut instance = cache.get_instance(&id, deps2).unwrap();
-        let params = mock_env(
+        let env = mock_env(
             &instance.api,
             "bob",
             &coin("15", "earth"),
             &coin("1015", "earth"),
         );
         let msg = b"{}";
-        let res = call_handle(&mut instance, &params, msg).unwrap();
+        let res = call_handle(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
         let _ = cache.store_instance(&id, instance).unwrap();
 
         // run contract 1 - just sanity check - results validate in contract unit tests
         let mut instance = cache.get_instance(&id, deps1).unwrap();
-        let params = mock_env(
+        let env = mock_env(
             &instance.api,
             "sue",
             &coin("15", "earth"),
             &coin("1015", "earth"),
         );
         let msg = b"{}";
-        let res = call_handle(&mut instance, &params, msg).unwrap();
+        let res = call_handle(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
         let _ = cache.store_instance(&id, instance);

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -116,7 +116,7 @@ mod test {
     use tempfile::TempDir;
 
     use crate::calls::{call_handle, call_init};
-    use cosmwasm::mock::{dependencies, mock_params, MockApi, MockStorage};
+    use cosmwasm::mock::{dependencies, mock_env, MockApi, MockStorage};
     use cosmwasm::types::coin;
 
     static CONTRACT_0_7: &[u8] = include_bytes!("../testdata/contract_0.7.wasm");
@@ -157,7 +157,7 @@ mod test {
         let mut instance = cache.get_instance(&id, deps).unwrap();
 
         // run contract
-        let params = mock_params(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
 
         // call and check
@@ -175,14 +175,14 @@ mod test {
         let mut instance = cache.get_instance(&id, deps).unwrap();
 
         // init contract
-        let params = mock_params(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
         let res = call_init(&mut instance, &params, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
 
         // run contract - just sanity check - results validate in contract unit tests
-        let params = mock_params(
+        let params = mock_env(
             &instance.api,
             "verifies",
             &coin("15", "earth"),
@@ -206,7 +206,7 @@ mod test {
 
         // init instance 1
         let mut instance = cache.get_instance(&id, deps1).unwrap();
-        let params = mock_params(&instance.api, "owner1", &coin("1000", "earth"), &[]);
+        let params = mock_env(&instance.api, "owner1", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "sue", "beneficiary": "mary"}"#.as_bytes();
         let res = call_init(&mut instance, &params, msg).unwrap();
         let msgs = res.unwrap().messages;
@@ -215,7 +215,7 @@ mod test {
 
         // init instance 2
         let mut instance = cache.get_instance(&id, deps2).unwrap();
-        let params = mock_params(&instance.api, "owner2", &coin("500", "earth"), &[]);
+        let params = mock_env(&instance.api, "owner2", &coin("500", "earth"), &[]);
         let msg = r#"{"verifier": "bob", "beneficiary": "john"}"#.as_bytes();
         let res = call_init(&mut instance, &params, msg).unwrap();
         let msgs = res.unwrap().messages;
@@ -224,7 +224,7 @@ mod test {
 
         // run contract 2 - just sanity check - results validate in contract unit tests
         let mut instance = cache.get_instance(&id, deps2).unwrap();
-        let params = mock_params(
+        let params = mock_env(
             &instance.api,
             "bob",
             &coin("15", "earth"),
@@ -238,7 +238,7 @@ mod test {
 
         // run contract 1 - just sanity check - results validate in contract unit tests
         let mut instance = cache.get_instance(&id, deps1).unwrap();
-        let params = mock_params(
+        let params = mock_env(
             &instance.api,
             "sue",
             &coin("15", "earth"),

--- a/lib/vm/src/calls.rs
+++ b/lib/vm/src/calls.rs
@@ -2,14 +2,14 @@ use snafu::ResultExt;
 
 use cosmwasm::serde::{from_slice, to_vec};
 use cosmwasm::traits::{Api, Storage};
-use cosmwasm::types::{ContractResult, Params, QueryResult};
+use cosmwasm::types::{ContractResult, Env, QueryResult};
 
 use crate::errors::{Error, ParseErr, RuntimeErr, SerializeErr};
 use crate::instance::{Func, Instance};
 
 pub fn call_init<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
-    params: &Params,
+    params: &Env,
     msg: &[u8],
 ) -> Result<ContractResult, Error> {
     let params = to_vec(params).context(SerializeErr {})?;
@@ -20,7 +20,7 @@ pub fn call_init<S: Storage + 'static, A: Api + 'static>(
 
 pub fn call_handle<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
-    params: &Params,
+    params: &Env,
     msg: &[u8],
 ) -> Result<ContractResult, Error> {
     let params = to_vec(params).context(SerializeErr {})?;

--- a/lib/vm/src/calls.rs
+++ b/lib/vm/src/calls.rs
@@ -9,22 +9,22 @@ use crate::instance::{Func, Instance};
 
 pub fn call_init<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
-    params: &Env,
+    env: &Env,
     msg: &[u8],
 ) -> Result<ContractResult, Error> {
-    let params = to_vec(params).context(SerializeErr {})?;
-    let data = call_init_raw(instance, &params, msg)?;
+    let env = to_vec(env).context(SerializeErr {})?;
+    let data = call_init_raw(instance, &env, msg)?;
     let res: ContractResult = from_slice(&data).context(ParseErr {})?;
     Ok(res)
 }
 
 pub fn call_handle<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
-    params: &Env,
+    env: &Env,
     msg: &[u8],
 ) -> Result<ContractResult, Error> {
-    let params = to_vec(params).context(SerializeErr {})?;
-    let data = call_handle_raw(instance, &params, msg)?;
+    let env = to_vec(env).context(SerializeErr {})?;
+    let data = call_handle_raw(instance, &env, msg)?;
     let res: ContractResult = from_slice(&data).context(ParseErr {})?;
     Ok(res)
 }
@@ -54,27 +54,27 @@ pub fn call_query_raw<S: Storage + 'static, A: Api + 'static>(
 
 pub fn call_init_raw<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
-    params: &[u8],
+    env: &[u8],
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    call_raw(instance, "init", params, msg)
+    call_raw(instance, "init", env, msg)
 }
 
 pub fn call_handle_raw<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
-    params: &[u8],
+    env: &[u8],
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    call_raw(instance, "handle", params, msg)
+    call_raw(instance, "handle", env, msg)
 }
 
 fn call_raw<S: Storage + 'static, A: Api + 'static>(
     instance: &mut Instance<S, A>,
     name: &str,
-    params: &[u8],
+    env: &[u8],
     msg: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    let param_offset = instance.allocate(params)?;
+    let param_offset = instance.allocate(env)?;
     let msg_offset = instance.allocate(msg)?;
 
     let func: Func<(u32, u32), u32> = instance.func(name)?;

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -135,7 +135,7 @@ where
 mod test {
     use crate::calls::{call_handle, call_init, call_query};
     use crate::testing::mock_instance;
-    use cosmwasm::mock::mock_params;
+    use cosmwasm::mock::mock_env;
     use cosmwasm::types::coin;
 
     static CONTRACT_0_7: &[u8] = include_bytes!("../testdata/contract_0.7.wasm");
@@ -178,7 +178,7 @@ mod test {
         instance.set_gas(orig_gas);
 
         // init contract
-        let params = mock_params(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
         let res = call_init(&mut instance, &params, msg).unwrap();
         let msgs = res.unwrap().messages;
@@ -190,7 +190,7 @@ mod test {
 
         // run contract - just sanity check - results validate in contract unit tests
         instance.set_gas(orig_gas);
-        let params = mock_params(
+        let params = mock_env(
             &instance.api,
             "verifies",
             &coin("15", "earth"),
@@ -214,7 +214,7 @@ mod test {
         instance.set_gas(orig_gas);
 
         // init contract
-        let params = mock_params(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
         let res = call_init(&mut instance, &params, msg);
         assert!(res.is_err());
@@ -228,7 +228,7 @@ mod test {
         instance.set_gas(orig_gas);
 
         // init contract
-        let params = mock_params(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
         let _res = call_init(&mut instance, &params, msg).unwrap().unwrap();
 

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -178,9 +178,9 @@ mod test {
         instance.set_gas(orig_gas);
 
         // init contract
-        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        let res = call_init(&mut instance, &params, msg).unwrap();
+        let res = call_init(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(msgs.len(), 0);
 
@@ -190,14 +190,14 @@ mod test {
 
         // run contract - just sanity check - results validate in contract unit tests
         instance.set_gas(orig_gas);
-        let params = mock_env(
+        let env = mock_env(
             &instance.api,
             "verifies",
             &coin("15", "earth"),
             &coin("1015", "earth"),
         );
         let msg = b"{}";
-        let res = call_handle(&mut instance, &params, msg).unwrap();
+        let res = call_handle(&mut instance, &env, msg).unwrap();
         let msgs = res.unwrap().messages;
         assert_eq!(1, msgs.len());
 
@@ -214,9 +214,9 @@ mod test {
         instance.set_gas(orig_gas);
 
         // init contract
-        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        let res = call_init(&mut instance, &params, msg);
+        let res = call_init(&mut instance, &env, msg);
         assert!(res.is_err());
     }
 
@@ -228,9 +228,9 @@ mod test {
         instance.set_gas(orig_gas);
 
         // init contract
-        let params = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
+        let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "verifies", "beneficiary": "benefits"}"#.as_bytes();
-        let _res = call_init(&mut instance, &params, msg).unwrap().unwrap();
+        let _res = call_init(&mut instance, &env, msg).unwrap().unwrap();
 
         // run contract - just sanity check - results validate in contract unit tests
         instance.set_gas(orig_gas);

--- a/lib/vm/src/testing.rs
+++ b/lib/vm/src/testing.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 use cosmwasm::mock::{dependencies, MockApi, MockStorage};
 use cosmwasm::serde::to_vec;
 use cosmwasm::traits::{Api, Storage};
-use cosmwasm::types::{ContractResult, Params, QueryResult};
+use cosmwasm::types::{ContractResult, Env, QueryResult};
 
 use crate::calls::{call_handle, call_init, call_query};
 use crate::instance::Instance;
@@ -23,7 +23,7 @@ pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi> {
 // this is inefficient here, but only used in test code
 pub fn init<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
     instance: &mut Instance<S, A>,
-    params: Params,
+    params: Env,
     msg: T,
 ) -> ContractResult {
     match to_vec(&msg) {
@@ -37,7 +37,7 @@ pub fn init<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
 // this is inefficient here, but only used in test code
 pub fn handle<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
     instance: &mut Instance<S, A>,
-    params: Params,
+    params: Env,
     msg: T,
 ) -> ContractResult {
     match to_vec(&msg) {

--- a/lib/vm/src/testing.rs
+++ b/lib/vm/src/testing.rs
@@ -19,35 +19,35 @@ pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi> {
 }
 
 // init mimicks the call signature of the smart contracts.
-// thus it moves params and msg rather than take them as reference.
+// thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
 pub fn init<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
     instance: &mut Instance<S, A>,
-    params: Env,
+    env: Env,
     msg: T,
 ) -> ContractResult {
     match to_vec(&msg) {
         Err(e) => ContractResult::Err(e.to_string()),
-        Ok(serialized_msg) => call_init(instance, &params, &serialized_msg).unwrap(),
+        Ok(serialized_msg) => call_init(instance, &env, &serialized_msg).unwrap(),
     }
 }
 
 // handle mimicks the call signature of the smart contracts.
-// thus it moves params and msg rather than take them as reference.
+// thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
 pub fn handle<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
     instance: &mut Instance<S, A>,
-    params: Env,
+    env: Env,
     msg: T,
 ) -> ContractResult {
     match to_vec(&msg) {
         Err(e) => ContractResult::Err(e.to_string()),
-        Ok(serialized_msg) => call_handle(instance, &params, &serialized_msg).unwrap(),
+        Ok(serialized_msg) => call_handle(instance, &env, &serialized_msg).unwrap(),
     }
 }
 
 // query mimicks the call signature of the smart contracts.
-// thus it moves params and msg rather than take them as reference.
+// thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
 pub fn query<S: Storage + 'static, A: Api + 'static, T: Serialize + JsonSchema>(
     instance: &mut Instance<S, A>,

--- a/schema/contract_result.json
+++ b/schema/contract_result.json
@@ -64,10 +64,10 @@
                   }
                 },
                 "from_address": {
-                  "type": "string"
+                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
-                  "type": "string"
+                  "$ref": "#/definitions/HumanAddr"
                 }
               }
             }
@@ -88,13 +88,16 @@
               ],
               "properties": {
                 "contract_addr": {
-                  "type": "string"
+                  "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
                   "type": "string"
                 },
                 "send": {
-                  "type": "array",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
@@ -123,6 +126,9 @@
           }
         }
       ]
+    },
+    "HumanAddr": {
+      "type": "string"
     },
     "Response": {
       "type": "object",

--- a/schema/cosmos_msg.json
+++ b/schema/cosmos_msg.json
@@ -23,10 +23,10 @@
               }
             },
             "from_address": {
-              "type": "string"
+              "$ref": "#/definitions/HumanAddr"
             },
             "to_address": {
-              "type": "string"
+              "$ref": "#/definitions/HumanAddr"
             }
           }
         }
@@ -47,13 +47,16 @@
           ],
           "properties": {
             "contract_addr": {
-              "type": "string"
+              "$ref": "#/definitions/HumanAddr"
             },
             "msg": {
               "type": "string"
             },
             "send": {
-              "type": "array",
+              "type": [
+                "array",
+                "null"
+              ],
               "items": {
                 "$ref": "#/definitions/Coin"
               }
@@ -97,6 +100,9 @@
           "type": "string"
         }
       }
+    },
+    "HumanAddr": {
+      "type": "string"
     }
   }
 }

--- a/schema/env.json
+++ b/schema/env.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Params",
+  "title": "Env",
   "type": "object",
   "required": [
     "block",
@@ -40,6 +40,14 @@
         }
       }
     },
+    "CanonicalAddr": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
     "Coin": {
       "type": "object",
       "required": [
@@ -63,7 +71,7 @@
       ],
       "properties": {
         "address": {
-          "type": "string"
+          "$ref": "#/definitions/CanonicalAddr"
         },
         "balance": {
           "type": [
@@ -93,7 +101,7 @@
           }
         },
         "signer": {
-          "type": "string"
+          "$ref": "#/definitions/CanonicalAddr"
         }
       }
     }

--- a/schema/query_result.json
+++ b/schema/query_result.json
@@ -64,10 +64,10 @@
                   }
                 },
                 "from_address": {
-                  "type": "string"
+                  "$ref": "#/definitions/HumanAddr"
                 },
                 "to_address": {
-                  "type": "string"
+                  "$ref": "#/definitions/HumanAddr"
                 }
               }
             }
@@ -88,13 +88,16 @@
               ],
               "properties": {
                 "contract_addr": {
-                  "type": "string"
+                  "$ref": "#/definitions/HumanAddr"
                 },
                 "msg": {
                   "type": "string"
                 },
                 "send": {
-                  "type": "array",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
                   "items": {
                     "$ref": "#/definitions/Coin"
                   }
@@ -123,6 +126,9 @@
           }
         }
       ]
+    },
+    "HumanAddr": {
+      "type": "string"
     },
     "Response": {
       "type": "object",

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -17,7 +17,7 @@ use crate::imports::{dependencies, ExternalApi, ExternalStorage};
 use crate::memory::{alloc, consume_region, release_buffer};
 use crate::serde::{from_slice, to_vec};
 use crate::traits::Extern;
-use crate::types::{ContractResult, Params, QueryResult, Response};
+use crate::types::{ContractResult, Env, QueryResult, Response};
 
 /// cosmwasm_api_* exports mark which api level this contract is compiled with (and compatible with).
 /// they can be checked by cosmwasm-vm::compatibility.
@@ -45,15 +45,11 @@ pub extern "C" fn deallocate(pointer: *mut c_void) {
 
 /// do_init should be wrapped in an external "C" export, containing a contract-specific function as arg
 pub fn do_init<T: DeserializeOwned + JsonSchema>(
-    init_fn: &dyn Fn(
-        &mut Extern<ExternalStorage, ExternalApi>,
-        Params,
-        T,
-    ) -> Result<Response, Error>,
-    params_ptr: *mut c_void,
+    init_fn: &dyn Fn(&mut Extern<ExternalStorage, ExternalApi>, Env, T) -> Result<Response, Error>,
+    env_ptr: *mut c_void,
     msg_ptr: *mut c_void,
 ) -> *mut c_void {
-    match _do_init(init_fn, params_ptr, msg_ptr) {
+    match _do_init(init_fn, env_ptr, msg_ptr) {
         Ok(res) => res,
         Err(err) => make_error_c_string(err),
     }
@@ -63,13 +59,13 @@ pub fn do_init<T: DeserializeOwned + JsonSchema>(
 pub fn do_handle<T: DeserializeOwned + JsonSchema>(
     handle_fn: &dyn Fn(
         &mut Extern<ExternalStorage, ExternalApi>,
-        Params,
+        Env,
         T,
     ) -> Result<Response, Error>,
-    params_ptr: *mut c_void,
+    env_ptr: *mut c_void,
     msg_ptr: *mut c_void,
 ) -> *mut c_void {
-    match _do_handle(handle_fn, params_ptr, msg_ptr) {
+    match _do_handle(handle_fn, env_ptr, msg_ptr) {
         Ok(res) => res,
         Err(err) => make_error_c_string(err),
     }
@@ -87,20 +83,16 @@ pub fn do_query<T: DeserializeOwned + JsonSchema>(
 }
 
 fn _do_init<T: DeserializeOwned + JsonSchema>(
-    init_fn: &dyn Fn(
-        &mut Extern<ExternalStorage, ExternalApi>,
-        Params,
-        T,
-    ) -> Result<Response, Error>,
-    params_ptr: *mut c_void,
+    init_fn: &dyn Fn(&mut Extern<ExternalStorage, ExternalApi>, Env, T) -> Result<Response, Error>,
+    env_ptr: *mut c_void,
     msg_ptr: *mut c_void,
 ) -> Result<*mut c_void, Error> {
-    let params: Vec<u8> = unsafe { consume_region(params_ptr)? };
+    let env: Vec<u8> = unsafe { consume_region(env_ptr)? };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr)? };
-    let params: Params = from_slice(&params).context(ParseErr { kind: "Params" })?;
+    let env: Env = from_slice(&env).context(ParseErr { kind: "Env" })?;
     let msg: T = from_slice(&msg).context(ParseErr { kind: "InitMsg" })?;
     let mut deps = dependencies();
-    let res = init_fn(&mut deps, params, msg)?;
+    let res = init_fn(&mut deps, env, msg)?;
     let json = to_vec(&ContractResult::Ok(res)).context(SerializeErr {
         kind: "ContractResult",
     })?;
@@ -110,19 +102,19 @@ fn _do_init<T: DeserializeOwned + JsonSchema>(
 fn _do_handle<T: DeserializeOwned + JsonSchema>(
     handle_fn: &dyn Fn(
         &mut Extern<ExternalStorage, ExternalApi>,
-        Params,
+        Env,
         T,
     ) -> Result<Response, Error>,
-    params_ptr: *mut c_void,
+    env_ptr: *mut c_void,
     msg_ptr: *mut c_void,
 ) -> Result<*mut c_void, Error> {
-    let params: Vec<u8> = unsafe { consume_region(params_ptr)? };
+    let env: Vec<u8> = unsafe { consume_region(env_ptr)? };
     let msg: Vec<u8> = unsafe { consume_region(msg_ptr)? };
 
-    let params: Params = from_slice(&params).context(ParseErr { kind: "Params" })?;
+    let env: Env = from_slice(&env).context(ParseErr { kind: "Env" })?;
     let msg: T = from_slice(&msg).context(ParseErr { kind: "HandleMsg" })?;
     let mut deps = dependencies();
-    let res = handle_fn(&mut deps, params, msg)?;
+    let res = handle_fn(&mut deps, env, msg)?;
     let json = to_vec(&ContractResult::Ok(res)).context(SerializeErr {
         kind: "ContractResult",
     })?;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -97,7 +97,7 @@ impl Api for MockApi {
 
 // just set signer, sent funds, and balance - rest given defaults
 // this is intended for use in testcode only
-pub fn mock_params<T: Api, U: Into<HumanAddr>>(
+pub fn mock_env<T: Api, U: Into<HumanAddr>>(
     api: &T,
     signer: U,
     sent: &[Coin],
@@ -138,14 +138,14 @@ mod test {
     use crate::types::coin;
 
     #[test]
-    fn mock_params_arguments() {
+    fn mock_env_arguments() {
         let name = HumanAddr("my name".to_string());
         let api = MockApi::new(20);
 
         // make sure we can generate with &str, &HumanAddr, and HumanAddr
-        let a = mock_params(&api, "my name", &[], &coin("100", "atom"));
-        let b = mock_params(&api, &name, &[], &coin("100", "atom"));
-        let c = mock_params(&api, name, &[], &coin("100", "atom"));
+        let a = mock_env(&api, "my name", &[], &coin("100", "atom"));
+        let b = mock_env(&api, &name, &[], &coin("100", "atom"));
+        let c = mock_env(&api, name, &[], &coin("100", "atom"));
 
         // and the results are the same
         assert_eq!(a, b);

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -4,7 +4,7 @@ use snafu::ResultExt;
 
 use crate::errors::{ContractErr, Result, Utf8StringErr};
 use crate::traits::{Api, Extern, ReadonlyStorage, Storage};
-use crate::types::{BlockInfo, CanonicalAddr, Coin, ContractInfo, HumanAddr, MessageInfo, Params};
+use crate::types::{BlockInfo, CanonicalAddr, Coin, ContractInfo, Env, HumanAddr, MessageInfo};
 
 // dependencies are all external requirements that can be injected for unit tests
 pub fn dependencies(canonical_length: usize) -> Extern<MockStorage, MockApi> {
@@ -102,9 +102,9 @@ pub fn mock_params<T: Api, U: Into<HumanAddr>>(
     signer: U,
     sent: &[Coin],
     balance: &[Coin],
-) -> Params {
+) -> Env {
     let signer = signer.into();
-    Params {
+    Env {
         block: BlockInfo {
             height: 12_345,
             time: 1_571_797_419,

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,7 +62,7 @@ impl fmt::Display for CanonicalAddr {
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
-pub struct Params {
+pub struct Env {
     pub block: BlockInfo,
     pub message: MessageInfo,
     pub contract: ContractInfo,


### PR DESCRIPTION
Closes #99 

Renames generic `Params` to `Env`, as it contains information on the execution **Env**ironment of the contract. I can also rename to `Environ` or `Environment`, but I think `Env` is widely recognized abbreviation for programmers.