### PR TITLE
Make gas limit immutable in `cosmwasm_vm::instance::Instance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 - Remove export `check_api_compatibility`. The VM will take care of calling it.
 - Let `check_api_compatibility` check imports by fully qualified identifier
   `<module>.<name>`.
+- Make gas limit immutable in `cosmwasm_vm::instance::Instance`. It is passed
+  once at construction time and cannot publicly be manipulated anymore.
 
 ## 0.6
 

--- a/lib/vm/src/backends/singlepass.rs
+++ b/lib/vm/src/backends/singlepass.rs
@@ -40,5 +40,10 @@ pub fn set_gas(instance: &mut Instance, limit: u64) {
 
 pub fn get_gas(instance: &Instance) -> u64 {
     let used = metering::get_points_used(instance);
-    GAS_LIMIT - used
+    // when running out of gas, get_points_used can exceed GAS_LIMIT
+    if used < GAS_LIMIT {
+        GAS_LIMIT - used
+    } else {
+        0
+    }
 }

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -88,14 +88,19 @@ where
     }
 
     /// get instance returns a wasmer Instance tied to a previously saved wasm
-    pub fn get_instance(&mut self, id: &[u8], deps: Extern<S, A>) -> Result<Instance<S, A>, Error> {
+    pub fn get_instance(
+        &mut self,
+        id: &[u8],
+        deps: Extern<S, A>,
+        gas_limit: u64,
+    ) -> Result<Instance<S, A>, Error> {
         let hash = WasmHash::generate(&id);
 
         // pop from lru cache if present
         if let Some(cache) = &mut self.instances {
             if let Some(cached_instance) = cache.pop(&hash) {
                 self.stats.hits_instance += 1;
-                return Ok(Instance::from_wasmer(cached_instance, deps));
+                return Ok(Instance::from_wasmer(cached_instance, deps, gas_limit));
             }
         }
 
@@ -103,13 +108,13 @@ where
         let res = self.modules.load_with_backend(hash, backend());
         if let Ok(module) = res {
             self.stats.hits_module += 1;
-            return Instance::from_module(&module, deps);
+            return Instance::from_module(&module, deps, gas_limit);
         }
 
         // fall back to wasm cache (and re-compiling) - this is for backends that don't support serialization
         let wasm = self.load_wasm(id)?;
         self.stats.misses += 1;
-        Instance::from_code(&wasm, deps)
+        Instance::from_code(&wasm, deps, gas_limit)
     }
 
     pub fn store_instance(&mut self, id: &[u8], instance: Instance<S, A>) -> Option<Extern<S, A>> {
@@ -135,6 +140,7 @@ mod test {
     use cosmwasm::mock::{dependencies, mock_env, MockApi, MockStorage};
     use cosmwasm::types::coin;
 
+    static TESTING_GAS_LIMIT: u64 = 400_000;
     static CONTRACT_0_7: &[u8] = include_bytes!("../testdata/contract_0.7.wasm");
 
     #[test]
@@ -170,7 +176,7 @@ mod test {
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
         let deps = dependencies(20);
-        let _instance = cache.get_instance(&id, deps).unwrap();
+        let _instance = cache.get_instance(&id, deps, TESTING_GAS_LIMIT).unwrap();
         assert_eq!(cache.stats.hits_instance, 0);
         assert_eq!(cache.stats.hits_module, 1);
         assert_eq!(cache.stats.misses, 0);
@@ -184,11 +190,11 @@ mod test {
         let deps1 = dependencies(20);
         let deps2 = dependencies(20);
         let deps3 = dependencies(20);
-        let instance1 = cache.get_instance(&id, deps1).unwrap();
+        let instance1 = cache.get_instance(&id, deps1, TESTING_GAS_LIMIT).unwrap();
         cache.store_instance(&id, instance1);
-        let instance2 = cache.get_instance(&id, deps2).unwrap();
+        let instance2 = cache.get_instance(&id, deps2, TESTING_GAS_LIMIT).unwrap();
         cache.store_instance(&id, instance2);
-        let instance3 = cache.get_instance(&id, deps3).unwrap();
+        let instance3 = cache.get_instance(&id, deps3, TESTING_GAS_LIMIT).unwrap();
         cache.store_instance(&id, instance3);
         assert_eq!(cache.stats.hits_instance, 2);
         assert_eq!(cache.stats.hits_module, 1);
@@ -201,7 +207,7 @@ mod test {
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
         let deps = dependencies(20);
-        let mut instance = cache.get_instance(&id, deps).unwrap();
+        let mut instance = cache.get_instance(&id, deps, TESTING_GAS_LIMIT).unwrap();
 
         // run contract
         let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
@@ -219,7 +225,7 @@ mod test {
         let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
         let id = cache.save_wasm(CONTRACT_0_7).unwrap();
         let deps = dependencies(20);
-        let mut instance = cache.get_instance(&id, deps).unwrap();
+        let mut instance = cache.get_instance(&id, deps, TESTING_GAS_LIMIT).unwrap();
 
         // init contract
         let env = mock_env(&instance.api, "creator", &coin("1000", "earth"), &[]);
@@ -252,7 +258,7 @@ mod test {
         let deps2 = dependencies(20);
 
         // init instance 1
-        let mut instance = cache.get_instance(&id, deps1).unwrap();
+        let mut instance = cache.get_instance(&id, deps1, TESTING_GAS_LIMIT).unwrap();
         let env = mock_env(&instance.api, "owner1", &coin("1000", "earth"), &[]);
         let msg = r#"{"verifier": "sue", "beneficiary": "mary"}"#.as_bytes();
         let res = call_init(&mut instance, &env, msg).unwrap();
@@ -261,7 +267,7 @@ mod test {
         let deps1 = cache.store_instance(&id, instance).unwrap();
 
         // init instance 2
-        let mut instance = cache.get_instance(&id, deps2).unwrap();
+        let mut instance = cache.get_instance(&id, deps2, TESTING_GAS_LIMIT).unwrap();
         let env = mock_env(&instance.api, "owner2", &coin("500", "earth"), &[]);
         let msg = r#"{"verifier": "bob", "beneficiary": "john"}"#.as_bytes();
         let res = call_init(&mut instance, &env, msg).unwrap();
@@ -270,7 +276,7 @@ mod test {
         let deps2 = cache.store_instance(&id, instance).unwrap();
 
         // run contract 2 - just sanity check - results validate in contract unit tests
-        let mut instance = cache.get_instance(&id, deps2).unwrap();
+        let mut instance = cache.get_instance(&id, deps2, TESTING_GAS_LIMIT).unwrap();
         let env = mock_env(
             &instance.api,
             "bob",
@@ -284,7 +290,7 @@ mod test {
         let _ = cache.store_instance(&id, instance).unwrap();
 
         // run contract 1 - just sanity check - results validate in contract unit tests
-        let mut instance = cache.get_instance(&id, deps1).unwrap();
+        let mut instance = cache.get_instance(&id, deps1, TESTING_GAS_LIMIT).unwrap();
         let env = mock_env(
             &instance.api,
             "sue",

--- a/lib/vm/src/testing.rs
+++ b/lib/vm/src/testing.rs
@@ -14,10 +14,17 @@ use crate::calls::{call_handle, call_init, call_query};
 use crate::compatability::check_api_compatibility;
 use crate::instance::Instance;
 
+/// Gas limit for testing
+static DEFAULT_GAS_LIMIT: u64 = 500_000;
+
 pub fn mock_instance(wasm: &[u8]) -> Instance<MockStorage, MockApi> {
+    mock_instance_with_gas_limit(wasm, DEFAULT_GAS_LIMIT)
+}
+
+pub fn mock_instance_with_gas_limit(wasm: &[u8], gas_limit: u64) -> Instance<MockStorage, MockApi> {
     check_api_compatibility(wasm).unwrap();
     let deps = dependencies(20);
-    Instance::from_code(wasm, deps).unwrap()
+    Instance::from_code(wasm, deps, gas_limit).unwrap()
 }
 
 // init mimicks the call signature of the smart contracts.


### PR DESCRIPTION
During review, I found it hard to follow test code that included `instance.set_gas` calls. This seems to be an unnatural use of an instance. I could easily rewrite the tests in a way that set the gas limit once and calculate diffs using `get_gas`.

However, this PR does not work well together with the LRU cache. In

```rust
        // pop from lru cache if present
        if let Some(cache) = &mut self.instances {
            let val = cache.pop(&hash);
            if let Some(inst) = val {
                inst.leave_storage(Some(deps.storage));
                return Ok(inst);
            }
        }
```

it is not possible to reset the gas limit due API I want to remove.

I wonder if you have a good design around this. Re-using an "instance" seems to be counter-intuitive. I was thinking about caching raw `wasmer_runtime_core::Instance`s. 👍/👎/thoughts?