### PR TITLE
Add base64 type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bincode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cosmwasm"
 version = "0.6.3"
 dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1104,6 +1110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5850aeee1552f495dd0250014cf64b82b7c8879a89d83b33bbdace2cc4f63182"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [ "lib/vm" ]
 exclude = [ "contracts" ]
 
 [dependencies]
+base64 = "0.11.0"
 serde-json-wasm = "0.1.2"
 schemars = "0.5"
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -47,6 +47,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bincode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cosmwasm"
 version = "0.6.3"
 dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-json-wasm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -866,6 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5850aeee1552f495dd0250014cf64b82b7c8879a89d83b33bbdace2cc4f63182"

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -28,7 +28,9 @@ impl Base64 {
     }
 
     // this returns the base64 string
-    pub fn as_str(&self) -> &str { self.0.as_str() }
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
 
     // decode the raw data (guaranteed to be success as we control the data inside)
     pub fn decode(&self) -> Vec<u8> {
@@ -51,7 +53,8 @@ impl fmt::Display for Base64 {
 
 #[cfg(test)]
 mod test {
-    use crate::encoding::Base64;
+    use super::*;
+    use crate::serde::{from_slice, to_vec};
 
     #[test]
     fn encode_decode() {
@@ -96,5 +99,36 @@ mod test {
         let valid = "cm%uZG9taVo";
         let res = Base64::from_encoded(valid);
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn serialization_works() {
+        let data = vec![0u8, 187, 61, 11, 250, 0];
+        let encoded = Base64::new(&data);
+
+        let serialized = to_vec(&encoded).unwrap();
+        let deserialized: Base64 = from_slice(&serialized).unwrap();
+
+        assert_eq!(encoded, deserialized);
+        assert_eq!(data, deserialized.decode());
+    }
+
+    #[test]
+    fn deserialize_from_valid_string() {
+        let b64_str = "ALs9C/oA";
+        // this is the binary behind above string
+        let expected = vec![0u8, 187, 61, 11, 250, 0];
+
+        let serialized = to_vec(&b64_str).unwrap();
+        let deserialized: Base64 = from_slice(&serialized).unwrap();
+        assert_eq!(expected, deserialized.decode());
+    }
+
+    #[test]
+    fn deserialize_from_invalid_string() {
+        let invalid_str = "**BAD!**";
+        let serialized = to_vec(&invalid_str).unwrap();
+        let deserialized= from_slice::<Base64>(&serialized);
+        assert!(deserialized.is_err());
     }
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,42 +1,33 @@
 use std::fmt;
 
 use schemars::JsonSchema;
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{de, ser, Deserialize, Deserializer, Serialize};
 use snafu::ResultExt;
 
 use crate::errors::{Base64Err, Result};
 
-#[derive(Serialize, Clone, Default, Debug, PartialEq, JsonSchema)]
-pub struct Base64(String);
+#[derive(Clone, Default, Debug, PartialEq, JsonSchema)]
+pub struct Base64(pub Vec<u8>);
 
 // Base64 is guaranteed to be a valid Base64 string.
 // This is meant to be converted to-and-from raw bytes, but can also be json serialized as a string
 impl Base64 {
-    // encode raw data (binary -> base64 string)
-    pub fn new(data: &[u8]) -> Self {
-        Base64(base64::encode(data))
-    }
-
-    // take an (untrusted) string and assert it is valid base64 before casting it
-    // fail here, so decode is ensured to succeed.
-    //
-    // We also want to normalize it (to ensure trailing =), so we do a full decode-encode here
-    // FIXME: We can optimize this later.
-    pub fn from_encoded(encoded: &str) -> Result<Self> {
+    /// take an (untrusted) string and decode it into bytes.
+    /// fails if it is not valid base64
+    pub fn decode(encoded: &str) -> Result<Self> {
         let binary = base64::decode(&encoded).context(Base64Err {})?;
-        Ok(Base64::new(&binary))
+        Ok(Base64(binary))
     }
 
-    // this returns the base64 string
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
+    /// encode to string (guaranteed to be success as we control the data inside).
+    /// this returns normalized form (with trailing = if needed)
+    pub fn encode(&self) -> String {
+        base64::encode(&self.0)
     }
 
-    // decode the raw data (guaranteed to be success as we control the data inside)
-    pub fn decode(&self) -> Vec<u8> {
-        base64::decode(&self.0).unwrap()
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
     }
-
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -47,11 +38,18 @@ impl Base64 {
 
 impl fmt::Display for Base64 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        write!(f, "{}", self.encode())
     }
 }
 
-// all this to enforce json is correct when decoding
+impl From<&[u8]> for Base64 {
+    fn from(data: &[u8]) -> Self {
+        Self(data.to_vec())
+    }
+}
+
+
+// decode base64 string to binary
 impl<'de> Deserialize<'de> for Base64 {
     fn deserialize<D>(deserializer: D) -> Result<Base64, D::Error>
     where
@@ -74,7 +72,7 @@ impl<'de> de::Visitor<'de> for Base64Visitor {
     where
         E: de::Error,
     {
-        match Base64::from_encoded(v) {
+        match Base64::decode(v) {
             Ok(b64) => Ok(b64),
             Err(_) => Err(E::custom(format!("invalid base64: {}", v))),
         }
@@ -88,77 +86,72 @@ mod test {
 
     #[test]
     fn encode_decode() {
-        let data = b"hello";
-        let encoded = Base64::new(data);
+        let data: &[u8] = b"hello";
+        let encoded = Base64::from(data).encode();
         assert_eq!(8, encoded.len());
-        let decoded = encoded.decode();
+        let decoded = Base64::decode(&encoded).unwrap();
         assert_eq!(data, decoded.as_slice());
     }
 
     #[test]
     fn encode_decode_non_ascii() {
         let data = vec![12u8, 187, 0, 17, 250, 1];
-        let encoded = Base64::new(&data);
+        let encoded = Base64(data.clone()).encode();
         assert_eq!(8, encoded.len());
-        let decoded = encoded.decode();
-        assert_eq!(data, decoded);
+        let decoded = Base64::decode(&encoded).unwrap();
+        assert_eq!(data.as_slice(), decoded.as_slice());
     }
 
     #[test]
     fn from_valid_string() {
         let valid = "cmFuZG9taVo=";
-        let encoded = Base64::from_encoded(valid).unwrap();
-        assert_eq!(12, encoded.len());
-        assert_eq!(valid, encoded.as_str());
-        let decoded = encoded.decode();
+        let decoded = Base64::decode(valid).unwrap();
         assert_eq!(b"randomiZ", decoded.as_slice());
     }
 
     #[test]
     // this must be normalized form (with trailing =)
     fn from_shortened_string() {
-        let valid = "cmFuZG9taVo";
-        let encoded = Base64::from_encoded(valid).unwrap();
-        assert_eq!(12, encoded.len());
-        let decoded = encoded.decode();
+        let short = "cmFuZG9taVo";
+        let decoded = Base64::decode(short).unwrap();
         assert_eq!(b"randomiZ", decoded.as_slice());
     }
 
     #[test]
     fn from_invalid_string() {
         let valid = "cm%uZG9taVo";
-        let res = Base64::from_encoded(valid);
+        let res = Base64::decode(valid);
         assert!(res.is_err());
     }
 
-    #[test]
-    fn serialization_works() {
-        let data = vec![0u8, 187, 61, 11, 250, 0];
-        let encoded = Base64::new(&data);
-
-        let serialized = to_vec(&encoded).unwrap();
-        let deserialized: Base64 = from_slice(&serialized).unwrap();
-
-        assert_eq!(encoded, deserialized);
-        assert_eq!(data, deserialized.decode());
-    }
-
-    #[test]
-    fn deserialize_from_valid_string() {
-        let b64_str = "ALs9C/oA";
-        // this is the binary behind above string
-        let expected = vec![0u8, 187, 61, 11, 250, 0];
-
-        let serialized = to_vec(&b64_str).unwrap();
-        let deserialized: Base64 = from_slice(&serialized).unwrap();
-        assert_eq!(expected, deserialized.decode());
-    }
-
-    #[test]
-    fn deserialize_from_invalid_string() {
-        let invalid_str = "**BAD!**";
-        let serialized = to_vec(&invalid_str).unwrap();
-        let deserialized = from_slice::<Base64>(&serialized);
-        assert!(deserialized.is_err());
-    }
+//    #[test]
+//    fn serialization_works() {
+//        let data = vec![0u8, 187, 61, 11, 250, 0];
+//        let encoded = Base64(data);
+//
+//        let serialized = to_vec(&encoded).unwrap();
+//        let deserialized: Base64 = from_slice(&serialized).unwrap();
+//
+//        assert_eq!(encoded, deserialized);
+//        assert_eq!(data, deserialized.decode());
+//    }
+//
+//    #[test]
+//    fn deserialize_from_valid_string() {
+//        let b64_str = "ALs9C/oA";
+//        // this is the binary behind above string
+//        let expected = vec![0u8, 187, 61, 11, 250, 0];
+//
+//        let serialized = to_vec(&b64_str).unwrap();
+//        let deserialized: Base64 = from_slice(&serialized).unwrap();
+//        assert_eq!(expected, deserialized.decode());
+//    }
+//
+//    #[test]
+//    fn deserialize_from_invalid_string() {
+//        let invalid_str = "**BAD!**";
+//        let serialized = to_vec(&invalid_str).unwrap();
+//        let deserialized = from_slice::<Base64>(&serialized);
+//        assert!(deserialized.is_err());
+//    }
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -20,13 +20,11 @@ impl Binary {
         let binary = base64::decode(&encoded).context(Base64Err {})?;
         Ok(Binary(binary))
     }
-
     /// encode to base64 string (guaranteed to be success as we control the data inside).
     /// this returns normalized form (with trailing = if needed)
     pub fn to_base64(&self) -> String {
         base64::encode(&self.0)
     }
-
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_slice()
     }
@@ -50,6 +48,7 @@ impl From<&[u8]> for Binary {
     }
 }
 
+/// Serializes as a base64 string
 impl Serialize for Binary {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -59,7 +58,7 @@ impl Serialize for Binary {
     }
 }
 
-// decode base64 string to binary
+/// Deserializes as a base64 string
 impl<'de> Deserialize<'de> for Binary {
     fn deserialize<D>(deserializer: D) -> Result<Binary, D::Error>
     where

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,0 +1,56 @@
+use std::fmt;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::errors::{Base64Err, Result};
+
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
+pub struct Base64(pub String);
+
+impl Base64 {
+    // as_bytes will return a &[u8] reference to the string format. This should be good
+    // for most apps (slightly longer, but saves the transform cost)
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+    // decode will return the underlying bytes after decoding base64
+    pub fn decode(&self) -> Result<Vec<u8>> {
+        base64::decode(&self.0).context(Base64Err {})
+    }
+    // encode will construct this from raw binary (output of decode)
+    pub fn encode(data: &[u8]) -> Self {
+        Base64(base64::encode(data))
+    }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Display for Base64 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+impl From<&str> for Base64 {
+    fn from(data: &str) -> Self {
+        Base64(data.to_string())
+    }
+}
+
+impl From<String> for Base64 {
+    fn from(data: String) -> Self {
+        Base64(data)
+    }
+}
+
+impl From<&Base64> for Base64 {
+    fn from(data: &Base64) -> Self {
+        Base64(data.0.to_string())
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,12 @@ use snafu::Snafu;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub")]
 pub enum Error {
+    #[snafu(display("Invalid Base64 string: {}", source))]
+    Base64Err {
+        source: base64::DecodeError,
+        #[cfg(feature = "backtraces")]
+        backtrace: snafu::Backtrace,
+    },
     #[snafu(display("Contract error: {}", msg))]
     ContractErr {
         msg: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod exports;
 pub mod imports;
 
+pub mod encoding;
 pub mod errors;
 pub mod memory;
 pub mod mock;


### PR DESCRIPTION
Working on #122

Takes one piece from #133 

This is a safe `Base64` type, which guaranatees a normalized `Base64` form (adding in missing trailing `=` if needed). This can be used to produce better encodings in following PRs, but should capture all required type-safety.