### PR TITLE
Cache wasmer instances and add cache stats

### DIFF
--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -17,10 +17,17 @@ use crate::wasm_store::{load, save, wasm_hash};
 static WASM_DIR: &str = "wasm";
 static MODULES_DIR: &str = "modules";
 
+struct Stats {
+    hits_instance: u32,
+    hits_module: u32,
+    misses: u32,
+}
+
 pub struct CosmCache<S: Storage + 'static, A: Api + 'static> {
     wasm_path: PathBuf,
     modules: FileSystemCache,
     instances: Option<LruCache<WasmHash, wasmer_runtime_core::Instance>>,
+    stats: Stats,
     // Those two don't store data but only fix type information
     type_storage: PhantomData<S>,
     type_api: PhantomData<A>,
@@ -52,6 +59,11 @@ where
             modules,
             wasm_path,
             instances,
+            stats: Stats {
+                hits_instance: 0,
+                hits_module: 0,
+                misses: 0,
+            },
             type_storage: PhantomData::<S> {},
             type_api: PhantomData::<A> {},
         })
@@ -85,6 +97,7 @@ where
         // pop from lru cache if present
         if let Some(cache) = &mut self.instances {
             if let Some(cached_instance) = cache.pop(&hash) {
+                self.stats.hits_instance += 1;
                 return Ok(Instance::from_wasmer(cached_instance, deps));
             }
         }
@@ -92,11 +105,13 @@ where
         // try from the module cache
         let res = self.modules.load_with_backend(hash, backend());
         if let Ok(module) = res {
+            self.stats.hits_module += 1;
             return Instance::from_module(&module, deps);
         }
 
         // fall back to wasm cache (and re-compiling) - this is for backends that don't support serialization
         let wasm = self.load_wasm(id)?;
+        self.stats.misses += 1;
         Instance::from_code(&wasm, deps)
     }
 
@@ -150,6 +165,37 @@ mod test {
             Err(e) => panic!("Unexpected error {:?}", e),
             Ok(_) => panic!("Didn't reject wasm with invalid api"),
         }
+    }
+
+    #[test]
+    fn finds_cached_module() {
+        let tmp_dir = TempDir::new().unwrap();
+        let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
+        let id = cache.save_wasm(CONTRACT_0_7).unwrap();
+        let deps = dependencies(20);
+        let _instance = cache.get_instance(&id, deps).unwrap();
+        assert_eq!(cache.stats.hits_instance, 0);
+        assert_eq!(cache.stats.hits_module, 1);
+        assert_eq!(cache.stats.misses, 0);
+    }
+
+    #[test]
+    fn finds_cached_instance() {
+        let tmp_dir = TempDir::new().unwrap();
+        let mut cache = unsafe { CosmCache::new(tmp_dir.path(), 10).unwrap() };
+        let id = cache.save_wasm(CONTRACT_0_7).unwrap();
+        let deps1 = dependencies(20);
+        let deps2 = dependencies(20);
+        let deps3 = dependencies(20);
+        let instance1 = cache.get_instance(&id, deps1).unwrap();
+        cache.store_instance(&id, instance1);
+        let instance2 = cache.get_instance(&id, deps2).unwrap();
+        cache.store_instance(&id, instance2);
+        let instance3 = cache.get_instance(&id, deps3).unwrap();
+        cache.store_instance(&id, instance3);
+        assert_eq!(cache.stats.hits_instance, 2);
+        assert_eq!(cache.stats.hits_module, 1);
+        assert_eq!(cache.stats.misses, 0);
     }
 
     #[test]

--- a/lib/vm/src/cache.rs
+++ b/lib/vm/src/cache.rs
@@ -17,6 +17,7 @@ use crate::wasm_store::{load, save, wasm_hash};
 static WASM_DIR: &str = "wasm";
 static MODULES_DIR: &str = "modules";
 
+#[derive(Debug, Default, Clone)]
 struct Stats {
     hits_instance: u32,
     hits_module: u32,
@@ -59,11 +60,7 @@ where
             modules,
             wasm_path,
             instances,
-            stats: Stats {
-                hits_instance: 0,
-                hits_module: 0,
-                misses: 0,
-            },
+            stats: Stats::default(),
             type_storage: PhantomData::<S> {},
             type_api: PhantomData::<A> {},
         })

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -22,7 +22,8 @@ use crate::memory::{read_region, write_region};
 pub struct Instance<S: Storage + 'static, A: Api + 'static> {
     wasmer_instance: wasmer_runtime_core::instance::Instance,
     pub api: A,
-    storage: PhantomData<S>,
+    // This does not store data but only fixes type information
+    type_storage: PhantomData<S>,
 }
 
 impl<S, A> Instance<S, A>
@@ -78,7 +79,7 @@ where
         let res = Instance {
             wasmer_instance: wasmer_instance,
             api: deps.api,
-            storage: PhantomData::<S> {},
+            type_storage: PhantomData::<S> {},
         };
         res.leave_storage(Some(deps.storage));
         res


### PR DESCRIPTION
Closes #137

It turns out that reusing a wasmer instance from `Instance` is much easier than reusing the storage because the storage is needed to create the wasmer context, which makes things very complicated. This leaves the storage question untouched.