### PR TITLE
Use set_gas/get_gas implementations from master

### DIFF
--- a/lib/vm/src/backends/singlepass.rs
+++ b/lib/vm/src/backends/singlepass.rs
@@ -34,16 +34,20 @@ pub fn backend() -> Backend {
 }
 
 pub fn set_gas(instance: &mut Instance, limit: u64) {
-    let used = GAS_LIMIT - limit;
+    let used = if limit > GAS_LIMIT {
+        0
+    } else {
+        GAS_LIMIT - limit
+    };
     metering::set_points_used(instance, used)
 }
 
 pub fn get_gas(instance: &Instance) -> u64 {
     let used = metering::get_points_used(instance);
     // when running out of gas, get_points_used can exceed GAS_LIMIT
-    if used < GAS_LIMIT {
-        GAS_LIMIT - used
-    } else {
+    if used > GAS_LIMIT {
         0
+    } else {
+        GAS_LIMIT - used
     }
 }


### PR DESCRIPTION
The uses the better set_gas/get_gas implementations from current master and to make master -> 0.7 merge easier.

The `get_gas` is functionally the same but only uses the special case branch if the default expression is overflows, which I find easier to understand.